### PR TITLE
Update config files to have the right generated URLs

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -69,6 +69,6 @@ launch_buttons:
   colab_url                 : "" # The URL of Google Colab (https://colab.research.google.com)
 
 repository:
-  url                       : https://github.com/neuromatch/course-content-template  # The URL to your book's repository
+  url                       : https://github.com/neuromatch/NeuroAI_Course  # The URL to your book's repository
   path_to_book              : book  # A path to your book's folder, relative to the repository root.
   branch                    : main  # Which branch of the repository should be used when creating links


### PR DESCRIPTION
Update `_config.yml` so that the book build generates links to this repository and not the template repository.