### PR TITLE
Clean up D3 tutorials

### DIFF
--- a/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial1.ipynb
+++ b/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial1.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "__Content reviewers:__ Samuele Bolotta, Yizhou Chen, RyeongKyung Yoon, Ruiyi Zhang, Lily Chamakura, Hlib Solodzhuk\n",
     "\n",
-    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk\n"
+    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk, Patrick Mineault\n"
    ]
   },
   {
@@ -59,8 +59,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -103,8 +102,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -133,8 +131,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -178,8 +175,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -196,8 +192,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -281,8 +276,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -518,8 +512,7 @@
     "        if type(feats) is list:\n",
     "            feats = feats[-1]\n",
     "\n",
-    "        if args.use_cuda:\n",
-    "            feats = feats.cpu()\n",
+    "        feats = feats.cpu()\n",
     "\n",
     "        if len(feats.shape) > 2:\n",
     "            feats = feats.flatten(1)\n",
@@ -646,8 +639,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -688,8 +680,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -718,8 +709,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -765,8 +755,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -842,7 +831,7 @@
     "\n",
     "You are already provided with the trained models to save the time, still you are free to explore training code being included in the tutorial.\n",
     "\n",
-    "**Defining the MNIST Model**\n",
+    "### Defining the MNIST Model\n",
     "\n",
     "First, we define a neural network model that will be trained on the MNIST dataset. The MNIST dataset consists of 28x28 pixel images of handwritten digits (0 through 9). Our model, based on the LeNet architecture, includes two convolutional layers followed by dropout layers to reduce overfitting, and finally, fully connected layers to perform classification."
    ]
@@ -851,8 +840,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -893,19 +881,18 @@
     "execution": {}
    },
    "source": [
-    "**Training the Standard Model**\n",
+    "## Training the Standard Model\n",
     "\n",
-    "Once our model is defined, we proceed to train it on the MNIST dataset. Training involves feeding batches of images and their corresponding labels to the model, adjusting the model's weights based on the loss computed from its predictions and the actual labels through backpropagation and gradient descent. This process is iterated over multiple epochs to improve the model's accuracy.\n",
+    "Once the model is defined, we would normally proceed to train it on the MNIST dataset. Training involves feeding batches of images and their corresponding labels to the model, adjusting the model's weights based on the loss computed from its predictions and the actual labels through backpropagation and gradient descent. This process is iterated over multiple epochs to improve the model's accuracy.\n",
     "\n",
-    "Training code provided here is commented and you can miss it by heading towards the load of the already trained model."
+    "The training code is copied here for reference, in a commented out block. We ran this code offline and saved a checkpoint. In the interest of time, we'll skip ahead to loading this checkpoint into the model."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -931,8 +918,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -968,8 +954,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -983,15 +968,24 @@
     "execution": {}
    },
    "source": [
-    "Here, we generate adversarial images using the Fast Gradient Sign Method (FGSM). This is a popular and straightforward adversarial attack technique designed to test the robustness of neural networks. Developed by Ian Goodfellow and his colleagues in 2014, FGSM backprops through the neural network to create perturbed inputs that maximize the loss."
+    "Here, we generate adversarial images using the Fast Gradient Sign Method (FGSM). This is a popular and straightforward adversarial attack technique designed to test the robustness of neural networks. Developed by Ian Goodfellow and his colleagues in 2014, FGSM backprops through the neural network to create perturbed inputs that maximize the loss:\n",
+    "\n",
+    "$$\\text{perturbed image} = \\text{image} + \\epsilon \\cdot \\text{sign}(\\nabla_{\\text{image}} J(\\text{image}, \\text{true label}))$$\n",
+    "\n",
+    "where:\n",
+    "\n",
+    "* $\\text{perturbed image}$ is the adversarial image\n",
+    "* $\\text{image}$ is the original input image\n",
+    "* $\\epsilon$ is the magnitude of the perturbation\n",
+    "* $\\nabla_{\\text{image}} J(\\text{image}, \\text{true label})$ is the gradient of the loss with respect to the input image\n",
+    "* $\\text{sign}(\\cdot)$ returns the sign of the argument"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1015,19 +1009,18 @@
     "execution": {}
    },
    "source": [
-    "**Training the Adversarially Robust Model**\n",
+    "## Training the Adversarially Robust Model\n",
     "\n",
     "With adversarial examples at hand, we now train a model designed to be robust against such examples. The idea is to include adversarial examples in the training process, enabling the model to learn from and defend against them.\n",
     "\n",
-    "Again, there is training code defined below which is commented and you are presented with already adversarially trained network."
+    "Again, we've included the training code in a commented out section, and you are presented with already adversarially trained network."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1043,8 +1036,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1058,8 +1050,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1083,28 +1074,27 @@
     "execution": {}
    },
    "source": [
-    "**Evaluating Model Robustness**\n",
+    "## Evaluating Model Robustness\n",
     "\n",
-    "After training, it's essential to evaluate how well the models perform, particularly in the presence of adversarial examples. We do this by testing the models on both standard and adversarial images and comparing their accuracies.\n",
+    "Now that we have a trained model, we evaluate its resistance to adversarial attacks. We do this by testing the models on both standard and adversarial images and comparing their accuracies.\n",
     "\n",
-    "Note that these adversarially generated images are indistinguishable from the real ones, but they decrease standard model performances dramatically, while adversarially trained model is robust to this kind of attack."
+    "While these adversarially generated images are visually indistinguishable from the original ones, they cause dramatic decreases in standard model, while adversarially trained model is robust to this kind of attack."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
     "# @markdown Test model\n",
     "\n",
-    "# test adversairal robustness\n",
-    "print(\"For standard model trained without adversarial examples:\")\n",
+    "# test adversarial robustness\n",
+    "print(\"For standard model trained without adversarial examples (eps=0.2):\")\n",
     "test_adversarial(model, adv_imgs, targets)\n",
-    "print(\"For adversrially trained model:\")\n",
+    "print(\"For adversrially trained model (eps=0.2):\")\n",
     "test_adversarial(model_robust, adv_imgs_advmodel, targets)"
    ]
   },
@@ -1125,15 +1115,14 @@
    "source": [
     "## Extracting Model Features and Analyzing Representations\n",
     "\n",
-    "With the models trained and adversarial images generated, we proceed to extract features from different layers of our networks using [torchlens](https://github.com/johnmarktaylor91/torchlens), a package for extracting neural network activations and visualizing their computational graph.  This step is crucial for understanding how data representations differ across layers and models, especially under adversarial conditions."
+    "With the models trained and adversarial images generated, we proceed to extract features from different layers of our networks using [torchlens](https://github.com/johnmarktaylor91/torchlens), a package for extracting neural network activations and visualizing their computational graph.  This will allow us to peer into the data representations at different layers of the models in normal and adversarial conditions."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1146,9 +1135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_model_advimgs = extract_features(model, adv_imgs, return_layers)\n",
@@ -1178,9 +1165,13 @@
    "source": [
     "## What is a RDM?\n",
     "\n",
-    "Before diving into the practical applications, let's clarify what an RDM is. An RDM is a tool used to measure and visualize the dissimilarities in the responses of a neural system to different inputs. It is represented as a matrix $M$ where each element $M_{ij}$ measures how dissimilar the network's responses are to the $i$-th and $j$-th input. In the context of this tutorial, we use correlation distance to calculate the elements of the RDMs. Correlation distance is based on the Pearson correlation coefficient, which quantifies the linear relationship between two variables. Specifically, correlation distance is defined as: $\\text{Correlation distance} = 1 - r$, where $r$ is the Pearson correlation coefficient. Therefore, the element $M_{ij} = 1 - r(x_i, x_j)$, where $x_i, x_j$ refer to the model representations of the $i$-th and $j$-th inputs.\n",
+    "Before diving into the practical applications, let's clarify what an RDM is. An RDM is a tool used to measure and visualize the dissimilarities in the responses of a neural system to different inputs. It is represented as a matrix $M$ where each element $M_{ij}$ measures how dissimilar the network's responses are to the $i$-th and $j$-th input. Specifically:\n",
     "\n",
-    "RDMs are crucial for understanding how well a model can differentiate between various types of inputs, which is a key aspect of generalization. They are particularly useful in deep learning as they help illustrate the level at which different layers of a network or different netowrks recognize and differentiate between input categories. A well-performing model will show clear patterns of dissimilarity corresponding to different input categories, especially in deeper layers."
+    "$$M_{ij} = 1 - r(x_i, x_j)$$\n",
+    "\n",
+    "Here $r(x_i, x_j)$ is the Pearson correlation coefficient between the representations of the $i$-th and $j$-th inputs. $1 - r(x_i, x_j)$ is also known as the correlation distance, which quantifies the dissimilarity between two inputs.\n",
+    "\n",
+    "RDMs help us understand how well a model differentiates between various types of inputs, which is a key aspect of generalization. They are particularly useful in deep learning as they help illustrate the level at which different layers of a network or different networks recognize and differentiate between input categories. A well-performing model will show clear patterns of dissimilarity corresponding to different input categories, especially in deeper layers."
    ]
   },
   {
@@ -1189,6 +1180,8 @@
     "execution": {}
    },
    "source": [
+    "## Visualizing RDMs\n",
+    "\n",
     "We first visualize the category structure by computing the RDM of the labels. To see clear blocks in RDMs—where blocks indicate that inputs of the same class are represented similarly—we need to ensure that input images are organized and grouped by their class labels before calculating the RDM. Here, we have 10 classes (number 0-9), each class with 5 samples, which sums up to 50 input images. Recall that each element of the RDM $M_{ij}$ refers the dissimilarity between the representations of the $i$-th and $j$-th inputs. Make sure you understand the figure of RDM of the labels below."
    ]
   },
@@ -1196,8 +1189,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1231,8 +1223,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1245,8 +1236,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1269,9 +1259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#to_remove explanation\n",
@@ -1279,7 +1267,7 @@
     "\"\"\"\n",
     "Question: For adversarial images, how do the RDMs change when comparing representations from the standard model to the adversarially trained model?\n",
     "\n",
-    "For clean images representing the same digit, their representations in the deeper layers of the network are remarkably similar and align well with the inherent category structure, manifesting as a distinct block effect. In contrast, this block effect is less pronounced in the earlier layers of the network. The initial layers focus more on capturing general and granular visual features. This progression from generic to more refined feature extraction across layers underscores the hierarchical nature of learning in deep neural networks, where complex representations are built upon the simpler ones extracted at earlier stages.\n",
+    "For clean images representing the same digit, their representations in the deeper layers of the network are remarkably similar and align well with the inherent category structure. This manifests as a block diagonal structure. In contrast, this block effect is less pronounced in the earlier layers of the network. The initial layers focus more on capturing general and granular visual features. This progression from generic to more refined feature extraction across layers underscores the hierarchical nature of learning in deep neural networks, where complex representations are built upon the simpler ones extracted at earlier stages.\n",
     "\"\"\";"
    ]
   },
@@ -1305,8 +1293,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1319,8 +1306,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1343,9 +1329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#to_remove explanation\n",
@@ -1353,8 +1337,8 @@
     "\"\"\"\n",
     "Question: For adversarial images, how do the RDMs change when comparing representations from the standard model to the adversarially trained model?\n",
     "\n",
-    "Note for adversarial images, the representation similarity of the standard model within each category (the block effect) is notably disrupted in the deeper layers.\n",
-    "Conversely, for the adversarially trained model, despite the introduction of adversarial examples, the representation similarity matrix for preserves its block-like structure across categories.\n",
+    "With adversarial images, the within-category representation similarity (the block effect) is disrupted in the deeper layers of the standard model.\n",
+    "The adversarially trained model preserves its block-like structure across categories when presented with adversarial images, however.\n",
     "\"\"\";"
    ]
   },
@@ -1372,9 +1356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#to_remove explanation\n",
@@ -1382,20 +1364,8 @@
     "\"\"\"\n",
     "Question: How does the RDMs relate to the performances of the standard and the adversarially trained models on clean and adversarial images?\n",
     "\n",
-    "RDMs provide a visual and quantitative way to analyze how a neural network processes and represents different stimuli. By comparing the similarity of responses within the network across various inputs, the RDM can reveal significant insights into the network's internal representations and, consequently, its ability to generalize.\n",
+    "RDMs provide a visual and quantitative way to analyze how a neural network processes and represents different stimuli. By comparing the similarity of responses within the network across various inputs, the RDM can reveal insights into the network's internal representations and, consequently, its ability to generalize.\n",
     "\"\"\";"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "Both the standard and the adversarially trained models show clear, distinct blocks in the RDM when inputs from the same category are represented similarly (high intra-class similarity) and inputs from different categories are distinct (low inter-class similarity). This differentiation is crucial for the model to achieve high accuracies on unseen test data from the same distribution.\n",
-    "\n",
-    "However, for adversarial images, the block effect of the standard model is notably disrupted. This disruption correlates with a diminished test accuracy when the model is evaluated on adversarial images, highlighting the vulnerability of the standard model to adversarial perturbations.\n",
-    "For adversarially trained model, the structural preservation of its RDMs indicates that the model's internal representations of the stimuli remain robust against adversarial manipulation, allowing it to maintain high accuracy on adversarial images.\n"
    ]
   },
   {
@@ -1424,6 +1394,8 @@
     "\n",
     "Note that the predicted outputs for the test stimuli are a weighted combination of the outputs for training stimuli, where the weights depend on the inner products of the training and test stimuli. **Thus, the more similar a training stimulus is to a given test stimulus, the more strongly the output for that training stimulus will contribute to the output for that test stimulus**. To give another example, in the case of a radial basis function readout, the relevant notion of similarity would be the Euclidean distance between the inputs.\n",
     "\n",
+    "## Interactive exercise\n",
+    "\n",
     "In this interactive exercise, you will explore how the similarity between training and test stimuli predicts how the network generalizes. The task is to use linear regression on activations from our MNIST network from above in order to predict the \"legibility\" of images of different digit images. You play the role of the human rater providing the outputs for the training data, and will rate the legibility of each individual training image from 1-10 using the provided sliders (on the left), where a 10 is perfectly legible, and a 1 is totally illegible. Based on these provided ratings, a ridge regression is trained under the hood to predict those ratings using the activations from the selected layer of the neural network, and the resulting regression model is then applied to new images, yielding predicted legibility ratings for these images (red numbers at the bottom).\n",
     "\n",
     "The color-coded matrix shows the dot product similarity between activations for the training images (rows) and test images (columns)--yellow means that the two images are highly similar based on the dot product of the activations for those images, and dark blue means the two images are highly dissimilar. The goal of this exercise is to explore how the predicted legibility of the test stimuli is determined by your legibility ratings of the training stimuli, and the similarity of the training and test stimuli.\n",
@@ -1438,21 +1410,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# from google.colab import output\n",
-    "# output.enable_custom_widget_manager()"
+    "# Enable the custom widget manager in Colab.\n",
+    "try:\n",
+    "    from google.colab import output\n",
+    "    output.enable_custom_widget_manager()\n",
+    "except:\n",
+    "    pass"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1620,7 +1593,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial2.ipynb
+++ b/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial2.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "__Content reviewers:__ Samuele Bolotta, Yizhou Chen, RyeongKyung Yoon, Ruiyi Zhang, Lily Chamakura, Hlib Solodzhuk\n",
     "\n",
-    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk"
+    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk, Patrick Mineault"
    ]
   },
   {
@@ -41,15 +41,14 @@
     "\n",
     "*Estimated timing of tutorial: 40 minutes*\n",
     "\n",
-    "In this tutorial we aim to understand that in networks computation can be understood as a sequence of transformations of the representation of the input, where each transformation can remove information, preserve other information, and change the format in which the information is represented.\n"
+    "In this tutorial, we aim to understand computations in networks as a sequence of transformations of the representation of the input. We'll see that each transformation can remove information, preserve other information, and change the format in which the information is represented.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -83,8 +82,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -97,8 +95,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -142,8 +139,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -160,8 +156,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -209,7 +204,7 @@
     "    \"\"\"\n",
     "\n",
     "    with plt.xkcd():\n",
-    "        fig = plt.figure(figsize=(14, 4))\n",
+    "        fig = plt.figure(figsize=(8, 4))\n",
     "        gs = fig.add_gridspec(1, len(model_rdms))\n",
     "        fig.subplots_adjust(wspace=0.2, hspace=0.2)\n",
     "\n",
@@ -224,7 +219,7 @@
     "            rdm = rdm / np.max(rdm)\n",
     "\n",
     "            ax = plt.subplot(gs[0,l])\n",
-    "            ax_ = ax.imshow(rdm, cmap='Greys')\n",
+    "            ax_ = ax.imshow(rdm, cmap='magma_r')\n",
     "            ax.set_title(f'{layer}')\n",
     "\n",
     "        fig.subplots_adjust(right=0.9)\n",
@@ -280,11 +275,14 @@
     "\n",
     "        rdms_comp = rsatoolbox.rdm.compare(rdms, rdms, method=rdm_comp_method)\n",
     "        if rdm_comp_method == 'cosine':\n",
-    "            rdms_comp = np.arccos(rdms_comp)\n",
+    "            rdms_comp = 1 - rdms_comp\n",
     "        rdms_comp = np.nan_to_num(rdms_comp, nan=0.0)\n",
     "\n",
+    "        # Symmetrize\n",
+    "        rdms_comp = (rdms_comp + rdms_comp.T) / 2.0\n",
+    "\n",
     "        # reduce dim to 2\n",
-    "        transformer = manifold.MDS(n_components = 2, max_iter=1000, n_init=10, normalized_stress='auto')\n",
+    "        transformer = manifold.MDS(n_components = 2, max_iter=1000, n_init=10, normalized_stress='auto', dissimilarity=\"precomputed\")\n",
     "        dims= transformer.fit_transform(rdms_comp)\n",
     "\n",
     "        # remove duplicates of the input layer from multiple models\n",
@@ -302,9 +300,9 @@
     "        ax_ = ax.imshow(rdms_comp, cmap='viridis_r')\n",
     "        fig.subplots_adjust(left=0.2)\n",
     "        cbar_ax = fig.add_axes([-0.01, 0.2, 0.01, 0.5])\n",
-    "        #cbar_ax.text(-7, 0.05, 'angles between rdms', size=10, rotation=90)\n",
+    "        #cbar_ax.text(-7, 0.05, 'dissimilarity between rdms', size=10, rotation=90)\n",
     "        fig.colorbar(ax_, cax=cbar_ax,location='left')\n",
-    "        ax.set_title('Angles between layer rdms')\n",
+    "        ax.set_title('Dissimilarity between layer rdms')\n",
     "        ax.set_xticks(np.arange(len(ax_ticks)), labels=ax_ticks, fontsize=7, rotation=83)\n",
     "        ax.set_yticks(np.arange(len(ax_ticks)), labels=ax_ticks, fontsize=7)\n",
     "        [t.set_color(i) for (i,t) in zip(tick_colors, ax.xaxis.get_ticklabels())]\n",
@@ -351,7 +349,7 @@
     "            if t == 'MDS': transformers.append(manifold.MDS(n_components = 2, normalized_stress='auto'))\n",
     "            if t == 't-SNE': transformers.append(manifold.TSNE(n_components = 2, perplexity=40, verbose=0))\n",
     "\n",
-    "        fig = plt.figure(figsize=(14, 4*len(transformers)))\n",
+    "        fig = plt.figure(figsize=(8, 2.5*len(transformers)))\n",
     "        # and we add one plot per reference point\n",
     "        gs = fig.add_gridspec(len(transformers), len(model_features))\n",
     "        fig.subplots_adjust(wspace=0.2, hspace=0.2)\n",
@@ -390,8 +388,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -593,12 +590,9 @@
     "    args = parser.parse_args('')\n",
     "\n",
     "    use_cuda = torch.cuda.is_available() #not args.no_cuda and\n",
-    "    use_mps = not args.no_mps and torch.backends.mps.is_available()\n",
     "\n",
     "    if use_cuda:\n",
     "        device = torch.device(\"cuda\")\n",
-    "    elif use_mps:\n",
-    "        device = torch.device(\"mps\")\n",
     "    else:\n",
     "        device = torch.device(\"cpu\")\n",
     "\n",
@@ -813,8 +807,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -855,8 +848,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -885,8 +877,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -934,15 +925,14 @@
     "execution": {}
    },
    "source": [
-    "We are going to use the same models, standard and adversarially trained, as in the previous tutorial, thus they are already prepared to get the visualizations."
+    "We are going to use the same models, standard and adversarially trained, as in the previous tutorial."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -960,15 +950,14 @@
     "execution": {}
    },
    "source": [
-    "In order to better visualize the sturcture in the model features, we grab 5 test images from each of the 10 digit categories. Below is a simple function to perform that. For the purpose of the visualization, we order the test images by category identity."
+    "In order to better visualize the structure of the model features, we grab 5 test images from each of the 10 digit categories. Below is a simple function to perform that. For the purpose of the visualization, we order the test images by category identity."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -990,8 +979,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1007,15 +995,14 @@
     "execution": {}
    },
    "source": [
-    "We can then focus on the main steps for visualization. We extract the features from these specific layers of the model for the sampled test images."
+    "We now extract the features from the intermediate layers of the model for the sampled test images."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1041,9 +1028,9 @@
     "execution": {}
    },
    "source": [
-    "Now for each of the test images, we have the model features from each layer of the trained network. We can look at how the representational (dis)similarity between these samples changes across the layers of the network. For each layer, we flatten the feautres so that each test image is represented by a vector (i.e. a point in space) and then we use the rsatooblox to compute the euclidean distances between the points in that reprsentational space.\n",
+    "Now for each of the test images, we have the model features from each layer of the trained network. We can look at how the representational (dis)similarity between these samples changes across the layers of the network. For each layer, we flatten the features so that each test image is represented by a vector (i.e. a point in space) and then we use the `rsatooblox` to compute the Euclidean distances between the points in that representational space.\n",
     "\n",
-    "The result is a matrix of distances between each two samples for each layer."
+    "The result is a matrix of distances between each pair of samples for each layer."
    ]
   },
   {
@@ -1052,20 +1039,18 @@
     "execution": {}
    },
    "source": [
-    "We can now plot the rdms for the input pixels and the two conv and two fully connected layers below.\n",
+    "We can now plot the RDMs for the input pixels, the two convolutional, and the two fully connected layers below.\n",
     "\n",
-    "The dimension of these RDMs are `#stimuli` by `#stimuli`.\n",
-    "The brighter cells show smaller dissimlarity between the two stimuli and the diagonal would have the dissimiarity of 0 (comparing the representation of one image to itself).\n",
+    "The RDMs are of dimension `#stimuli` by `#stimuli`. The brighter cells show smaller dissimilarity between the two stimuli. The diagonal has a dissimilarity of 0, as each image is maximally similar to itself.\n",
     "\n",
-    "Since the instances of each category are next to each other, the brighter blocks emerging around the diagonal show that the representatiaons for category instances become similar to one another across the levels of the hierarchy."
+    "Since the instances of each category are next to each other, the brighter blocks emerging around the diagonal show that the representations for category instances become similar to one another across the levels of the hierarchy."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1086,9 +1071,7 @@
     "execution": {}
    },
    "source": [
-    "Computation in the network can be understood as the transformation of representational geometries because the information-content of the representation at each stage are captured by its representational geometry.\n",
-    "\n",
-    "As we see in above rdms the geomety captures how the representation in later layers become more similar for instances of the same category since this model was trained for classification.\n"
+    "Computation in the network can be understood as the transformation of representational geometries. As we see in the above RDMs the geometry captures how the representation in later layers becomes more similar for instances of the same category since this model was trained for classification.\n"
    ]
   },
   {
@@ -1099,9 +1082,9 @@
    "source": [
     "## Dimensionality reduction\n",
     "\n",
-    "Another way to examine the geometry of the representaion changing across layers is by reducing the dimensionality and displaying the samples in 2D space.\n",
+    "Another way to examine the geometry of the representation changing across layers is by reducing the dimensionality and displaying the samples in 2D space.\n",
     "\n",
-    "The representaionl spaces of each layer of a deep network project each stimulus to a point in very high dimentional spaces. Methods such as PCA (principal component analysis), MDS (Multidimensional_scaling), and t-SNE (t-distributed stochastic neighbor embedding) attemp to capture the same geometry in lower dimensions.\n",
+    "The representational spaces of each layer of a deep network project each stimulus to a point in a very high-dimensional space. Methods such as PCA (principal component analysis), MDS (Multidimensional_scaling), and t-SNE (t-distributed stochastic neighbor embedding) attempt to capture the same geometry in lower dimensions.\n",
     "\n",
     "Below we look at the representational geometry of the same network layers using these methods."
    ]
@@ -1112,7 +1095,7 @@
     "execution": {}
    },
    "source": [
-    "For this visulization we take 500 samples from the test set and we color code them based on their category. The figure below shows the scatter plots for these samples across the layers of the network. Each panel is the 2D projection of the feature representations using a specific method.\n",
+    "For this visualization, we take 500 samples from the test set and we color-code them based on their category. The figure below shows the scatter plots for these samples across the layers of the network. Each panel is the 2D projection of the feature representations using a specific method.\n",
     "\n",
     "The methods all show that image representations progressively cluster based on category across the layers of the network."
    ]
@@ -1121,8 +1104,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1135,7 +1117,6 @@
     "#imgs, labels = next(iter(test_loader))\n",
     "\n",
     "model_features = extract_features(model, imgs.to(device), return_layers)\n",
-    "\n",
     "plot_dim_reduction(model_features, labels, transformer_funcs =['PCA', 'MDS', 't-SNE'])"
    ]
   },
@@ -1145,19 +1126,25 @@
     "execution": {}
    },
    "source": [
-    "## Representational path\n",
+    "## Representational path: from comparing representations to comparing RDMs\n",
     "\n",
-    "We can now go a step further and think of the computational steps in a network as steps in a path in the space of representational geometries.\n",
+    "We can now go a step further and think of the computational steps in a network as steps in a path in the space of representational geometries. Each layer in the network is changing the geometry to make it more and more like the desired geometry, which are the labels for a network trained for classification. What we'll do is to *[compare RDM matrices](https://rsatoolbox.readthedocs.io/en/stable/comparing.html)* across layers. \n",
     "\n",
-    "This means that each stage in the network is changing the geometry to make it more and more like the desired geometry which would be the labels for a network trained for classification.\n",
+    "### Comparing RDMs\n",
     "\n",
-    "To examine this process, we first have to quantify what the geometry after each step looks like. For this we can calculate the rdms based on the euclidean distances between the representations of images for each layer.\n",
+    "The first step, as before, is to calculate RDMs based on the Euclidean distances between the representations of images for each layer. We stack these RDMs into a 3d tensor:\n",
     "\n",
-    "The next step is to quantify how different the geometries from each step of the network are from one another. To perform this operation we first flatten the rdms from different model steps to make them a vector and then we can look at the angles between those vectors. Note that this measure of distance is between the representational geometries of different layers and not the representations themselves.\n",
+    "$$M(\\text{layer i}, \\text{image j}, \\text{image k})$$\n",
     "\n",
-    "In this tutorial we compute the similarity between geometries with a metric measure like the arccos of cos distance between the RDMs from different layers of the network. The resulting matrix has the dimentions of #model_computational_steps by #model_computational_steps.\n",
+    "The next step is to quantify how the geometries change across the layers. To perform this operation we first flatten the RDMs to obtain a 2d matrix:\n",
     "\n",
-    "The last step to visualize the path is to then embed the distances between the geometries in a lower dimensional space. We use MDS to reduce the dimensions to two in order to show each computational step as a point in a 2D space."
+    "$$\\hat M(\\text{layer i}, \\text{image j x image k})$$\n",
+    "\n",
+    "We can then calculate the distances between the different rows of this new matrix. It's like an RDM matrix of the RDM matrices! This new measure of distance captures the representational geometries of different layers,  not the representations themselves.\n",
+    "\n",
+    "We compute the similarity between geometries using the cosine dissimilarity. The resulting matrix has the dimensions of `#layers` by `#layers`.\n",
+    "\n",
+    "The last step to visualize the path is to embed the distances between the geometries in a lower dimensional space. We use MDS to reduce the dimensions to 2 in order to show each computational step as a point in a 2D space."
    ]
   },
   {
@@ -1172,9 +1159,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1195,13 +1188,17 @@
     "execution": {}
    },
    "source": [
-    "The left panel shows the angles between the rdms that catpure the representational geometry for each layer.\n",
+    "The left panel shows the dissimilarities between the RDMs that capture the representational geometry for each layer.\n",
     "\n",
-    "The brigher colors indicate higher similarity. The diagonal is the angle between a layer geometry with itself which is zero. The brighter colors around the diagonal show that the distances between adjacent layers are smaller and therefore each step is not chaning the representation too much.\n",
+    "The brighter colors indicate higher similarity. The diagonal is 0, since each layer is maximally similar to itself. The brighter blocks around the diagonal show that distances between blocks of adjacent layers are small.\n",
     "\n",
-    "The figure on the right shows the embedding of these angles for each layer in a 2D space using MDS. This figure basically tries to capturet the same distances between the layers as shown in the matrix on the left in a 2D space. Connecting the steps starting from the input (shown as the black square) forms a path in the space of representional geometries. The last step in this path (the softmax layer) reaches close to the embedding of the lables in the same 2D space.\n",
+    "The figure on the right shows the embedding of these distances in a 2D space using MDS. This figure captures the same distances between the layers shown in the matrix on the left in a 2D space. Connecting the steps starting from the input (shown as the black square) forms a path in the space of representional geometries. The last step in this path (the softmax layer) is similar to the embedding of the labels (denoted by an asterisk) in the same 2D space.\n",
     "\n",
-    "There are a few things to note about the path. One is that the path is generally smooth. This shows that the steps in how the representatoins change are not big, which we could also observe from the distance matrix on the left. From the matrix, we can also see that the distance between the representaionl geomety of the input and the lables is large but we see these two points somewhat close to each other in the path. This is partly becuase MDS tries to optimize to capture all the distances in the 2D space, they cannot all be veridically captured and a stronger curvature is introduced to the path. Therefore details of the curvature in 2D should be interpreted with caution. However, the size of the steps are generally informative. For example, we see in the left matrix that there is a big change in the representiaonal geometry going form conv to fully connected layers, corresponding to a larger step in the path.\n",
+    "There are a few things to note about the path: \n",
+    "\n",
+    "1. The path is generally smooth. This shows that each layer only slightly changes the representations, which we could also observe from the distance matrix on the left. \n",
+    "2. The distance between the representational geometry of the input and the labels is large but we see these two points somewhat close to each other in the path. This is partly because MDS tries to optimize to capture all the distances in the 2D space, they cannot all be veridically captured and a stronger curvature is introduced to the path. Therefore details of the curvature in 2D should be interpreted with caution. \n",
+    "3. The size of the steps is generally informative. For example, we see in the left matrix that there is a big change in the representational geometry going from the convolutional to the fully connected layers, corresponding to a larger step in the path.\n",
     "\n",
     "Thus the computation performed by this model is a path from the geometry of the input pixels to the geometry of the ground truth labels."
    ]
@@ -1214,7 +1211,7 @@
    "source": [
     "### Think!\n",
     "\n",
-    "1. How do you think the representational path will be different if we take a smaller sample of images to create the RDMs?"
+    "1. How do you think the representational path will change if we take a smaller sample of images to create the RDMs?"
    ]
   },
   {
@@ -1223,15 +1220,14 @@
     "execution": {}
    },
    "source": [
-    "To test what will actually happen by taking a sample of 5 images per category and visualizing the path."
+    "Let's find out by taking a sample of 5 images per category and visualizing the path."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1252,7 +1248,7 @@
     "execution": {}
    },
    "source": [
-    "As you can see the two paths are very similar. As mentioned earlier, The differences that we see here (such as different rotations) are not meaningful differences as different runs of the MDS can vary along such factors. We should judge the general paths of the models to compare them."
+    "As you can see the two paths are very similar. Differences such reflections and rotations are not meaningful as different runs of the MDS can vary along such factors. We should judge the general paths of the models to compare them."
    ]
   },
   {
@@ -1263,7 +1259,7 @@
    "source": [
     "## Adversarial images\n",
     "\n",
-    "Adversarial images pose a generalization challange to DNNs. Here we examine how this challenge and lower perofrmance are reflected in the the representational geometry path. First we use FGSM (Fast Gradient Sign method) to generate adversarial images for the trained feedforward model. This is a \"white-boxed\" attack that uses the gradients from the model loss with respect to to an image to adjust the image in order to maximize the loss. The pretrained model is already available for you to use.\n"
+    "Adversarial images pose a generalization challange to DNNs. Here we examine how this challenge and lower performance are reflected in the the representational geometry path. First we use FGSM (Fast Gradient Sign method) to generate adversarial images for the trained feedforward model. This is a \"white-box\" attack that uses the gradients from the model loss with respect to to an image to adjust the image in order to maximize the loss. \n"
    ]
   },
   {
@@ -1272,15 +1268,16 @@
     "execution": {}
    },
    "source": [
-    "We can also observe the signature of these mistakes reflected in the layer wise geometry of the representation. When the model is applied to the adversarial images, the rdms no longer show the progressive emergence of block-wise structure strongly around the diagonal."
+    "### Representational geometry in standard network\n",
+    "\n",
+    "Once again, we can observe the signature of these mistakes reflected in the layer-wise geometry of the representation. When the model is applied to the adversarial images, the rdms no longer show the progressive emergence of block-wise structure strongly around the diagonal."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1295,11 +1292,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "execution": {}
+   },
+   "source": [
+    "### Representational geometry in an adversarially trained network\n",
+    "\n",
+    "Let's load up an adversarially trained network and verify that it performs well on a newly generated set of adversarial images."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1310,20 +1317,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "Testing the model on a newly generated set of adversarial images, we can see that it performs very well."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1347,8 +1344,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1368,15 +1364,13 @@
    "source": [
     "### Coding Exercise 1\n",
     "\n",
-    "Use MDS to visualize the changes in the representational geometry acorss the layers of this network in response to original mnist test images."
+    "Use MDS to visualize the changes in the representational geometry across the layers of this network in response to original MNIST test images."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#################################################\n",
@@ -1385,7 +1379,7 @@
     "#################################################\n",
     "\n",
     "return_layers = ['input', 'conv1', 'conv2', 'fc1', 'fc2']\n",
-    "imgs, labels = sample_images(test_loader, n=50) #grab 500 samples from the test set\n",
+    "imgs, labels = sample_images(test_loader, n=50) # grab 500 samples from the test set\n",
     "model_features = ...\n",
     "\n",
     "plot_dim_reduction(model_features, labels, transformer_funcs =['MDS'])"
@@ -1394,15 +1388,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
     "\n",
     "return_layers = ['input', 'conv1', 'conv2', 'fc1', 'fc2']\n",
-    "imgs, labels = sample_images(test_loader, n=50) #grab 500 samples from the test set\n",
+    "imgs, labels = sample_images(test_loader, n=50) # grab 500 samples from the test set\n",
     "model_features = extract_features(model_robust, imgs.to(device), return_layers)\n",
     "\n",
     "plot_dim_reduction(model_features, labels, transformer_funcs =['MDS'])"
@@ -1416,11 +1408,11 @@
    "source": [
     "## Comparing representational geometry paths between models\n",
     "\n",
-    "We can generalize our method to look at the representioanl geometry paths of multiple models. We will first compute the rdms for each layer of each network and then concatenate them all. Then we look at the angles between all the layers (from different models).\n",
+    "We can generalize our method to look at the representational geometry paths of multiple models. We will first compute the RDMs for each layer of each network and then concatenate them all. Then we look at the dissimilarity between all the layers (from different models).\n",
     "\n",
-    "In this case, we will be looking at the feedforward and the robust feedforward models. The left panel in the figure below shows the angles between the representational geometries of all the layers in these two models. Networks are color coded for clarity, with the original feedforward model shown in blue and the robust feedforward model shown in green. The input pixels are shown again in black and the ground truth labels in magenta.\n",
+    "In this case, we will be looking at the feedforward and the robust feedforward models. The left panel in the figure below shows the dissimilarity between the representational geometries of all the layers in these two models. Networks are color-coded for clarity, with the original feedforward model shown in blue and the robust feedforward model shown in green. The input pixels are shown again in black and the ground truth labels are in magenta.\n",
     "\n",
-    "Embedding this matrix in a 2D space with MDS again gives us the path that each nework took from the input images to the labels.\n",
+    "Embedding this matrix in a 2D space with MDS again gives us the path that each network took from the input images to the labels.\n",
     "\n",
     "In this case, they are both tested on the original MNIST test images and both can perform the task. This is reflected in both models reaching the labels."
    ]
@@ -1428,9 +1420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "imgs, labels = sample_images(test_loader, n=50) #grab 500 samples from the test set\n",
@@ -1449,15 +1439,13 @@
     "execution": {}
    },
    "source": [
-    "But what if we test the models on adversarial images. We can see below that in this case only the robust model can actually reach the labels.  "
+    "What if we test the models on adversarial images? We can see below that in this case, only the robust model can reach the labels.  "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "imgs, labels = sample_images(test_loader, n=50) #grab 500 samples from the test set\n",
@@ -1478,9 +1466,9 @@
     "execution": {}
    },
    "source": [
-    "When we use adversarial imges, the two networks are taking different and diverging paths in the space of representational geometries. With only the robust model arriving near the embedding of the lables.\n",
+    "When we use adversarial images, the two networks are taking diverging paths in the space of representational geometries. Only the robust model's representation converges towards the embedding of the labels.\n",
     "\n",
-    "We can see from this example that these path depend on the chosen stimuli!"
+    "We can see from this example that these paths depend on the chosen stimuli!"
    ]
   },
   {
@@ -1502,15 +1490,13 @@
    "source": [
     "### Coding Exercise 2\n",
     "\n",
-    "Train another instance of the model on the original MNIST data for only one epoch with a different seed. Then compare the representationl paths of the two instances that are both trained on the original MNIST with one another. Display the paths in blue and cyan colors."
+    "Train another instance of the model on the original MNIST data for only one epoch with a different seed. Then compare the representational paths of the two instances that are both trained on the original MNIST with one another. Display the paths in blue and cyan colors."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#################################################\n",
@@ -1532,9 +1518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
@@ -1552,9 +1536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "imgs, labels = sample_images(test_loader, n=50) #grab 500 samples from the test set\n",
@@ -1589,10 +1571,10 @@
     "\n",
     "*Estimated timing of tutorial: 40 minutes*\n",
     "\n",
-    "By the end of this tutorial you are able to:\n",
+    "In this tutorial, we:\n",
     "\n",
-    "- Understand how to characterize the computation that happens across different layers of a network as a path with each step gradually changing the geometry of the representation to go from input pixels to target labels.\n",
-    "- Examine the paths for different model architectures and different inputs and learn how to interpret them."
+    "- Characterized the computation that happens across different layers of a network as a path with each step gradually changing the geometry of the representation to go from input pixels to target labels.\n",
+    "- Examined the paths for different model architectures and different inputs and learned how to interpret them."
    ]
   },
   {
@@ -1614,9 +1596,9 @@
     "execution": {}
    },
    "source": [
-    "Just as the layers in a feedforward DNN can change the representational geometry in order to perfom the task, steps in a reucrrent network can reuse the same layer to reach the same computational depth.\n",
+    "Just as the layers in a feedforward DNN can change the representational geometry to perform a task, steps in a recurrent network can reuse the same layer to reach the same computational depth.\n",
     "\n",
-    "In this section, we look at a very simple recurrent network with only 2650 trainable paramters."
+    "In this section, we look at a very simple recurrent network with only 2650 trainable parameters."
    ]
   },
   {
@@ -1625,7 +1607,7 @@
     "execution": {}
    },
    "source": [
-    "Here is a simple diagram of this network\n",
+    "Here is a diagram of this network:\n",
     "\n",
     "![Recurrent convolutional neural network](https://github.com/neuromatch/NeuroAI_Course/blob/main/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/static/rcnn_tutorial.png?raw=true)"
    ]
@@ -1634,8 +1616,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1659,9 +1640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "train_nodes, _ = get_graph_node_names(model_recurrent)\n",
@@ -1674,15 +1653,13 @@
     "execution": {}
    },
    "source": [
-    "Plotting the rdms after each application of the conv2 operation shows the same progressive emergence of the blockwise structure around the diagonal mediating the correct classificaiton in this task."
+    "Plotting the rdms after each application of the conv2 operation shows the same progressive emergence of the blockwise structure around the diagonal mediating the correct classification in this task."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "imgs, labels = sample_images(test_loader, n=20)\n",
@@ -1705,9 +1682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "return_layers = ['conv2', 'conv2_1', 'conv2_2', 'conv2_3', 'conv2_4']\n",
@@ -1733,15 +1708,13 @@
     "execution": {}
    },
    "source": [
-    "We can look at recurrent computational steps of the model as a path in the representaionl geometry space."
+    "We can look at recurrent computational steps of the model as a path in the representational geometry space."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "imgs, labels = sample_images(test_loader, n=50) #grab 500 samples from the test set\n",
@@ -1760,15 +1733,13 @@
     "execution": {}
    },
    "source": [
-    "We can also look at the paths taken by the feedforwward and the reucrrent models and compare them."
+    "We can also look at the paths taken by the feedforward and the recurrent models and compare them."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "imgs, labels = sample_images(test_loader, n=50) #grab 500 samples from the test set\n",
@@ -1787,7 +1758,7 @@
     "execution": {}
    },
    "source": [
-    "What we can see here is that different models can take very different paths in the space of representational geomerties in order to map images to labels. This is because there exist many different functional mappings to do a classification task."
+    "What we can see here is that different models can take very different paths in the space of representational geometries to map images to labels. This is because there exist many different functional mappings to do a classification task."
    ]
   }
  ],
@@ -1821,7 +1792,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial3.ipynb
+++ b/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial3.ipynb
@@ -1282,11 +1282,6 @@
    "source": [
     "def plot_fmri_pattern(subject, roi, image_idx, ax):\n",
     "    pattern = fmri_patterns[subject][roi][image_idx]\n",
-    "    #pattern = np.pad(pattern, (0, 50 - pattern.shape[0] % 50))\n",
-    "    #pattern = pattern.reshape(-1, 50)\n",
-    "\n",
-    "    #ax.imshow(pattern, aspect='auto', vmin=-2.2, vmax=2.3, cmap='bwr')\n",
-    "    #ax.set_title(f\"Subject {subject}, ROI {roi}, Image {image_idx}\")\n",
     "    ax.plot(pattern)\n",
     "    ax.set_title(f\"Subject {subject}, ROI {roi}, Image {image_idx}\")\n",
     "    ax.set_xlabel(\"Voxel #\")\n",
@@ -1309,7 +1304,6 @@
     "plot_fmri_pattern(subject, roi, 75, ax)\n",
     "\n",
     "plt.legend(['non-face 1', 'non-face 2', 'face 1', 'face 2'])\n",
-    "\n",
     "plt.show()"
    ]
   },

--- a/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial3.ipynb
+++ b/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial3.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "__Content reviewers:__ Samuele Bolotta, Yizhou Chen, RyeongKyung Yoon, Ruiyi Zhang, Lily Chamakura, Hlib Solodzhuk\n",
     "\n",
-    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk\n"
+    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk, Patrick Mineault\n"
    ]
   },
   {
@@ -49,15 +49,14 @@
     "\n",
     "3. Discuss frequentist model comparison: This part of the tutorial will cover the basics of frequentist model comparison methods. It will provide an overview of the principles underlying these methods and their applications.\n",
     "\n",
-    "4. Indentify sources of estimation error and the motivation for model-comparative frequentist inference. You will learn about the three main sources of estimation error in statistical inference—measurement noise, stimulus sampling, and subject sampling. Additionally, the tutorial will explore how these sources of error justify the use of model-comparative frequentist inference, particularly through the application of the 2-factor bootstrap method. This section will detail the impact of each source of error on statistical inference and demonstrate how the 2-factor bootstrap approach helps in mitigating these errors during model comparison."
+    "4. Identify sources of estimation error and the motivation for model-comparative frequentist inference. You will learn about the three main sources of estimation error in statistical inference—measurement noise, stimulus sampling, and subject sampling. Additionally, the tutorial will explore how these sources of error justify the use of model-comparative frequentist inference, particularly through the application of the 2-factor bootstrap method. This section will detail the impact of each source of error on statistical inference and demonstrate how the 2-factor bootstrap approach helps in mitigating these errors during model comparison."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -91,8 +90,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -105,8 +103,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -179,8 +176,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -197,8 +193,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -993,8 +988,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1063,8 +1057,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1131,24 +1124,16 @@
     "execution": {}
    },
    "source": [
-    "In this section we are goint to download and explore the data used in the tutorial."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "Initially, we will load fMRI data specifically targeting the V1 (primary visual cortex) and FFA (fusiform face area) regions, corresponding to a predefined set of images. This step is crucial for understanding how these brain areas respond to visual stimuli."
+    "In this section we are going to download and explore the data used in the tutorial. \n",
+    "\n",
+    "We will load from the [Natural Scene Dataset](https://naturalscenesdataset.org/). NSD is a large 7T fMRI dataset of 8 adults viewing more than 73,000 photos of natural scenes. We have taken a small subset of 90 images from NSD and have pre-extracted the fMRI data for V1 and Fusiform Face Area (FFA) from 8 subjects. Both of these areas are part of the visual cortex; V1 is known to respond to low-level visual features, while the FFA is famously responsive to high-level features, in particular faces."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1163,8 +1148,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1172,18 +1156,6 @@
     "# @markdown\n",
     "\n",
     "display(IMG(filename=\"NSD.png\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "execution": {}
-   },
-   "source": [
-    "We take fMRI response patterns from the [Natural Scene Dataset](https://naturalscenesdataset.org/).\n",
-    "NSD is a large 7T fMRI dataset of 8 adults viewing more than 73 thousand photos of natural scenes.\n",
-    "\n",
-    "We have taken a small subset of 90 images from NSD and have pre-extracted the fRMI data for V1 and Fusiform Face Area (FFA) from 8 subjects."
    ]
   },
   {
@@ -1208,8 +1180,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1227,7 +1198,7 @@
    },
    "source": [
     "Now let's take a look at these images.\n",
-    "Notice that the first 45 images we selected have no faces, while the other 45 do have a face in them!\n",
+    "Notice that the first 45 images we selected have no faces, while the other 45 do have faces in them!\n",
     "So we should expect to see a 2x2 block pattern in the Fusiform Face Area (FFA) representational dissimilarity matrices (RDMs)."
    ]
   },
@@ -1235,8 +1206,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1268,17 +1238,14 @@
    },
    "source": [
     "Let's now load the fMRI patterns from the NSD dataset for these 90 images.\n",
-    "We have pre-extracted the patterns, so we just need to load numpy arrays from \".npy\" files.\n",
-    "\n",
-    "Note that we have 8 subjects and our regions of interest (ROIs) are V1 and FFA."
+    "We have pre-extracted the patterns, so we just need to load Numpy arrays from `.npy` files."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1304,39 +1271,53 @@
     "execution": {}
    },
    "source": [
-    "Let's now take a look at the fmri pattern of two non-face images and two face images."
+    "Let's now take a look at the pattern of responses for two non-face images and two face images."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def plot_fmri_pattern(subject, roi, image_idx, ax):\n",
     "    pattern = fmri_patterns[subject][roi][image_idx]\n",
-    "    pattern = np.pad(pattern, (0, 50 - pattern.shape[0] % 50))\n",
-    "    pattern = pattern.reshape(-1, 50)\n",
+    "    #pattern = np.pad(pattern, (0, 50 - pattern.shape[0] % 50))\n",
+    "    #pattern = pattern.reshape(-1, 50)\n",
     "\n",
-    "    ax.imshow(pattern, aspect='auto', vmin=-2.2, vmax=2.3, cmap='bwr')\n",
+    "    #ax.imshow(pattern, aspect='auto', vmin=-2.2, vmax=2.3, cmap='bwr')\n",
+    "    #ax.set_title(f\"Subject {subject}, ROI {roi}, Image {image_idx}\")\n",
+    "    ax.plot(pattern)\n",
     "    ax.set_title(f\"Subject {subject}, ROI {roi}, Image {image_idx}\")\n",
+    "    ax.set_xlabel(\"Voxel #\")\n",
+    "    ax.set_ylabel(\"Activation\")\n",
+    "    ax.set_xlim([200, 400])\n",
+    "    ax.set_ylim([-3, 3])\n",
     "\n",
-    "with plt.xkcd():\n",
-    "    fig, axs = plt.subplots(1, 4, figsize=(15, 3))\n",
-    "    subject = 1\n",
-    "    roi = \"FFA\"\n",
     "\n",
-    "    # non-face images\n",
-    "    plot_fmri_pattern(subject, roi, 1, axs[1])\n",
-    "    plot_fmri_pattern(subject, roi, 3, axs[0])\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "ax = plt.gca()\n",
+    "subject = 1\n",
+    "roi = \"FFA\"\n",
     "\n",
-    "    # face images\n",
-    "    plot_fmri_pattern(subject, roi, 57, axs[2])\n",
-    "    plot_fmri_pattern(subject, roi, 75, axs[3])\n",
+    "# non-face images\n",
+    "plot_fmri_pattern(subject, roi, 1, ax)\n",
+    "plot_fmri_pattern(subject, roi, 3, ax)\n",
     "\n",
-    "    plt.show()"
+    "# face images\n",
+    "plot_fmri_pattern(subject, roi, 57, ax)\n",
+    "plot_fmri_pattern(subject, roi, 75, ax)\n",
+    "\n",
+    "plt.legend(['non-face 1', 'non-face 2', 'face 1', 'face 2'])\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The activity is complex, but we clearly see several voxels (e.g. voel 275) that have higher activation for faces than for non-faces. This is as expected for the face-selective FFA."
    ]
   },
   {
@@ -1379,18 +1360,14 @@
     "execution": {}
    },
    "source": [
-    "AlexNet is a famous convolutional neural network that won the [ImageNet](https://en.wikipedia.org/wiki/ImageNet) challenge in 2012 and started the \"deep learning revolution\".\n",
-    "\n",
-    "We load a version of AlexNet that is already pre-trained on ImageNet.\n",
-    "This step may take a minute, feel free to read ahead."
+    "We load a version of AlexNet that is already pre-trained on ImageNet. This step may take a minute, feel free to read ahead."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1404,17 +1381,16 @@
     "execution": {}
    },
    "source": [
-    "To pass images through the model, we need to _preprocess_ them to be in the same format as the images passed shown to the model during training.\n",
+    "To pass images through the model, we need to _preprocess_ them to be in the same format as the images shown to the model during training.\n",
     "\n",
-    "With AlexNet this includes resizing the images to 224x224 and normalizing their color channels to particular values. We also need to turn them into PyTorch tensors."
+    "For AlexNet, this includes resizing the images to 224x224 and normalizing their color channels to particular values. We also need to turn them into PyTorch tensors."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1437,15 +1413,14 @@
     "execution": {}
    },
    "source": [
-    "Let's inspect AlexNet architecture to select some of the layers as our \"models\":"
+    "Let's inspect AlexNet architecture to select some of the layers as our models."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1464,15 +1439,14 @@
     "execution": {}
    },
    "source": [
-    "We extract activations from different layers of AlexNet looking at the same images that we got our NSD fMRI patterns from:"
+    "We extract activations from different layers of AlexNet processing the same images that were presented to people during the NSD task:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1494,8 +1468,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1531,9 +1504,9 @@
    "source": [
     "Now that we have fMRI patterns and AlexNet activations, the first step in representation similarity analysis (RSA) is to compute the representational dissimilarity matrices (RDMs). RSA characterizes the representational geometry of the brain region of interest (ROI) by estimating the representational distance for each pair of experimental conditions (e.g. different images).\n",
     "\n",
-    "RDMs represent how dissimilar neural activity patterns or model activations are for each stimulus. In our case, these will be 90x90 image-by-image matrices representing how dissimilar fMRI patterns or AlexNet layer activations to each image.\n",
+    "RDMs represent how dissimilar neural activity patterns or model activations are for each stimulus. In our case, these will be 90x90 image-by-image matrices representing how dissimilar fMRI patterns or AlexNet layer activations are for each image.\n",
     "\n",
-    "For instance, we expect that in FFA, there will be a huge distance between the 45 face and 45 non-face images (so we expect to see a 2x2 block pattern inside the RDM).\n",
+    "For instance, we expect that in FFA, there will be a large distance between the 45 face and 45 non-face images: we expect to see a 2x2 block pattern inside the RDM.\n",
     "\n",
     "## Creating RSA toolbox datasets\n",
     "\n",
@@ -1544,8 +1517,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1571,8 +1543,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1605,8 +1576,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1639,9 +1609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#################################################\n",
@@ -1659,9 +1627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
@@ -1687,15 +1653,13 @@
     "execution": {}
    },
    "source": [
-    "Here we use methods on the *rsatoolbox* `RDMs` object to select a subset of the RDMs."
+    "Here we use methods on the `rsatoolbox` RDM object to select a subset of the RDMs."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fmri_rdms = rsa.rdm.concat(fmri_rdms_list)\n",
@@ -1709,7 +1673,7 @@
     "execution": {}
    },
    "source": [
-    "As predicted above, you can see a 2x2 block-like pattern in the FFA fMRI pattern RDMs.\n",
+    "As predicted above, we can see a 2x2 block-like pattern in the FFA fMRI pattern RDMs.\n",
     "\n",
     "This is because we have 45 non-face images followed by 45 face images.\n",
     "\n",
@@ -1719,9 +1683,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# the same RDMs, using a different visualization method\n",
@@ -1743,9 +1705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fmri_rdms = rsa.rdm.concat(fmri_rdms_list)"
@@ -1754,9 +1714,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#################################################\n",
@@ -1771,9 +1729,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
@@ -1802,9 +1758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "alexnet_rdms = rsa.rdm.concat(alexnet_rdms_dict.values())\n",
@@ -1819,17 +1773,15 @@
    "source": [
     "Each RDM contains the dissimilarities for each pair of activation patterns extracted by the different layers.\n",
     "\n",
-    "We see a similar pattern emerge clustering face and non-face images in fully connected \"fc6\", \"fc7\", \"fc8\" layers.\n",
+    "We see a similar pattern emerge clustering face and non-face images in fully connected `fc6`, `fc7` and  `fc8` layers.\n",
     "\n",
-    "AlexNet seems to \"care\" about faces too, at least to some extent."
+    "AlexNet seems to represent faces differently than non-faces, at least to some extent."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# same RDMs, different visualization method\n",
@@ -1856,7 +1808,7 @@
    "source": [
     "In the second step of RSA, each model is evaluated by the accuracy of its prediction of the data RDM. To this end, we will use the RDMs we computed for each model representation.\n",
     "\n",
-    "Each model’s prediction of the data RDM is evaluated using an RDM comparator, in this case we will use the correlation coefficient."
+    "Each model’s prediction of the data RDM is evaluated using an RDM comparator. In this case, we will use the correlation coefficient."
    ]
   },
   {
@@ -1865,15 +1817,14 @@
     "execution": {}
    },
    "source": [
-    "First, let's look at the performance of different Alexnet layers against all the subjects"
+    "First, let's look at the performance of different Alexnet layers across all subjects."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1887,8 +1838,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1921,7 +1871,7 @@
     "\n",
     "To achieve this, we will employ bootstrap resampling—a statistical technique that involves resampling our existing dataset with replacement to generate multiple simulated samples. This approach allows us to mimic the process of conducting the experiment anew with different subjects.\n",
     "\n",
-    "First let's focus on generalization to new subjects. By bootstrapping the subject dataset, for each simulated sample, we can compute the predictive accuracy of our models on the subjects' RDMs. After running many simulations, we will accumulate a distribution of accuracy estimates. This distribution will enable us to perform statistical inferences about our models’ generalizability to new subjects. (Later, we will address the problem of generalizing to new stimuli as well.)"
+    "First, we'll focus on generalization to new subjects. By bootstrapping the subject dataset, for each simulated sample, we can compute the predictive accuracy of our models on the subjects' RDMs. After running many simulations, we will accumulate a distribution of accuracy estimates. This distribution will enable us to perform statistical inferences about our models’ generalizability to new subjects. Later, we will address the problem of generalizing to new stimuli as well."
    ]
   },
   {
@@ -1930,15 +1880,13 @@
     "execution": {}
    },
    "source": [
-    "Let's simulate a 'new' sample of subjects by bootstrap resampling, using the RSA toolbox."
+    "Let's simulate a *new* sample of subjects by bootstrap resampling, using the RSA toolbox."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "boot_rdms, idx = rsa.inference.bootstrap_sample_rdm(human_rdms, rdm_descriptor='subject')"
@@ -1950,17 +1898,16 @@
     "execution": {}
    },
    "source": [
-    "Now we plot the RDMs of the bootstrapped sample\n",
+    "Now we plot the RDMs of the bootstrapped sample.\n",
     "\n",
-    "Each RDM is a subject (note that some subjects might be repeated and some might be missing in the bootstrapped sample)"
+    "Each RDM is a subject (note that some subjects might be repeated and some might be missing in the bootstrapped sample)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -1988,7 +1935,7 @@
     "The first row shows the RDMs for each of the original 8 subjects. \n",
     "The second row shows 8 RDMs sampled from the set of 8 original RDMs with replacement. This is bootstrap resampling. It can be seen as a simulation of a \"new\" set of 8 subjects' RDMs. Notice that in this new set not all subjects are represented and some others might appear more than once.\n",
     "\n",
-    "The idea is to see how the results for the model evaluations would change had our data come from the above simulated sample of subjects."
+    "The idea is to see how the results for the model evaluations would change had our data come from this simulated sample of subjects."
    ]
   },
   {
@@ -1997,15 +1944,14 @@
     "execution": {}
    },
    "source": [
-    "Let's see the model performance on different bootstrap resampled subject sets"
+    "Let's see the model performance on different bootstrap resampled subject sets."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -2036,9 +1982,7 @@
     "\n",
     "1. Explore the results for a few simulated new cohorts: run the cell above a few times and see how to points (individual RDMs) and bars (means) change. \n",
     "\n",
-    "Hint: For different simulated sets of subjects, the mean correlation of their RDMs to the RDMs given by each layer may look quite different. For example, If a given subject's RDM correlates very closely with layer conv4, and that subject is overrepresented in the boostrap sample, the layer conv4 might yield a higher accuracy compared to the other layers. \n",
-    "\n",
-    "But how can we know if these differences in model performance are statistically significant?"
+    "Hint: For different simulated sets of subjects, the mean correlation of their RDMs to the RDMs given by each layer may look quite different. For example, if a given subject's RDM correlates very closely with layer `conv4`, and that subject is overrepresented in the bootstrap sample, the layer `conv4` might yield a higher accuracy compared to the other layers. "
    ]
   },
   {
@@ -2047,6 +1991,10 @@
     "execution": {}
    },
    "source": [
+    "## Comparing representations statistically\n",
+    "\n",
+    "How can we know if these differences in model performance are statistically significant?\n",
+    "\n",
     "That is what the third and final step of RSA does: we conduct inferential comparisons between models based on their accuracy in predicting the representational dissimilarity matrices (RDMs).\n",
     "\n",
     "We leverage the variability in the performance estimates observed in the bootstrapped samples to conduct statistical tests. These tests are designed to determine whether the differences in RDM prediction accuracy between models are statistically significant."
@@ -2055,9 +2003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plot_model_comparison_trans(result)"
@@ -2070,10 +2016,11 @@
    },
    "source": [
     "The Y-axis, again, shows RDM prediction accuracy, as measured by the correlation distance between the data RDMs and the model RDMs. \n",
-    "The error bars reflect the variability in this estimate across bootstrap samples (over subjects). The gray bar indicates the noise ceiling, which is a measure of how well any model could do, given the noise in the data. The gray arrows indicate the models that don't perform significantly better than the noise-ceiling. The white dots at the bottom of the bars indicate the models whose correlation distance to the data RDMs is significantly better than zero. \n",
+    "The error bars reflect the variability in this estimate across bootstrap samples over subjects). The gray bar indicates the noise ceiling, which is a measure of how well any model could do, given the noise in the data. The gray arrows indicate the models that don't perform significantly better than the noise-ceiling. The white dots at the bottom of the bars indicate the models whose correlation distance to the data RDMs is significantly better than zero. \n",
     "\n",
-    "Details of the figure above:\n",
-    "model comparisons: two-tailed t-test, FDR q < 0.01. Error bars indicate the standard error of the mean. One-sided comparisons of each model performance against 0 and against the lower-bound estimate of the noise ceiling are Bonferroni-corrected for the number of models."
+    "#### Details of the figure above\n",
+    "\n",
+    "Model comparisons are performed using two-tailed t-test, FDR q < 0.01. Error bars indicate the standard error of the mean. One-sided comparisons of each model's performance against 0 and against the lower-bound estimate of the noise ceiling are Bonferroni-corrected for the number of models."
    ]
   },
   {
@@ -2093,17 +2040,16 @@
    "source": [
     "We have applied a method that enables us to infer how well the models might perform when predicting neural activity patterns for a new cohort of subjects. However, this approach has not yet considered the variability that could arise from introducing a new set of stimuli to the participants.\n",
     "\n",
-    "To extend our inferences to the generalizability of the models with respect to new stimuli, we must replicate the bootstrapping procedure, focusing this time on the stimuli rather than the subjects.\n",
+    "To extend our inferences to the generalizability of the models to new stimuli, we will once again use a bootstrapping procedure, focusing this time on the stimuli rather than the subjects.\n",
     "\n",
-    "To do this, we will first maintain the original cohort of subjects and apply bootstrapping to resample the stimulus set. That is, for each subject we will sample a new RDM based on the RDM from that subject's original activation patterns. The RDM will contain the pairwise dissimilarities between the response patterns to a set of stimuli sampled with replacement from the original set of stimuli."
+    "To do this, we will first maintain the original cohort of subjects and apply bootstrapping to resample the stimulus set. That is, for each subject, we will sample a new RDM based on the RDM from that subject's original activation patterns. The RDM will contain the pairwise dissimilarities between the response patterns to a set of stimuli sampled with replacement from the original set of stimuli."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -2124,7 +2070,7 @@
    "source": [
     "As before, rerunning the cell above will show you the RDMs for a new set of bootstrap resampled stimuli each time.\n",
     "\n",
-    "Note that the block-like structure from before is generally preserved. This is because the stimuli are sorted, so that the face stimuli are still adjacent to other face stimuli and the same for non-face stimuli to other non-face stimuli. What changes are the speficic instances of stimuli that are taken into account when computing the RDM. For each bootstrap resample, some stimuli might appear more than once and some might be left out."
+    "Note that the block-like structure from before is generally preserved. This is because the stimuli are sorted, so that the face stimuli are still adjacent to other face stimuli, and non-face stimuli are adjacent to other non-face stimuli. What changes are the specific stimuli used when computing the RDM. For each bootstrap resample, some stimuli might appear more than once and some might be left out."
    ]
   },
   {
@@ -2139,9 +2085,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result = rsa.inference.eval_bootstrap_pattern(models, human_rdms, theta=None, method='corr', N=1000,\n",
@@ -2160,8 +2104,9 @@
     "The Y-axis shows RDM prediction accuracy, as measured by the correlation distance between the data RDMs and the model RDMs. \n",
     "The error bars reflect the variability in this estimate across bootstrap samples (over stimuli). The gray bar indicates the noise ceiling, which is a measure of how well any model could do, given the noise in the data. The gray arrows indicate the models that don't perform significantly better than the noise-ceiling. The white dots at the bottom of the bars indicate the models whose correlation distance to the data RDMs is significantly better than zero. \n",
     "\n",
-    "Details of the figure above:\n",
-    "model comparisons: two-tailed t-test, FDR q < 0.01. Error bars indicate the standard error of the mean. One-sided comparisons of each model performance against 0 and against the lower-bound estimate of the noise ceiling are Bonferroni-corrected for the number of models."
+    "#### Details of the figure above\n",
+    "\n",
+    "Model comparisons: two-tailed t-test, FDR q < 0.01. Error bars indicate the standard error of the mean. One-sided comparisons of each model performance against 0 and against the lower-bound estimate of the noise ceiling are Bonferroni-corrected for the number of models."
    ]
   },
   {
@@ -2182,9 +2127,9 @@
     "execution": {}
    },
    "source": [
-    "For generalization across both the subject and stimulus populations, we can use a two-factor bootstrap method. For an in-depth discussion of this technique, refer to Schütt et al., 2023.\n",
+    "For generalization across both the subject and stimulus populations, we can use a two-factor bootstrap method. For an in-depth discussion of this technique, refer to [Schütt et al., 2023](https://elifesciences.org/articles/82566).\n",
     "\n",
-    "We can use the RSA toolbox to implement bootstrap resampling of subjects and stimuli simultaneously. It it important to note that a naive 2-factor bootstrap approach triple-counts the variance contributed by the measurement noise. For further understanding of this issue, see the explanation provided by Schütt et al. Fortunately, the RSA toolbox has an implementation that corrects for this potential overestimation. \n",
+    "We can use the RSA toolbox to implement bootstrap resampling of subjects and stimuli simultaneously. It is important to note that a naive 2-factor bootstrap approach triple-counts the variance contributed by the measurement noise. For further understanding of this issue, see the explanation provided by Schütt et al. Fortunately, the RSA toolbox has an implementation that corrects this potential overestimation. \n",
     "\n",
     "Let's evaluate the performance of the models with simultaneous bootstrap resampling of the subjects and stimuli."
    ]
@@ -2192,9 +2137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "eval_result = rsa.inference.eval_dual_bootstrap(models, fmri_rdms.subset('roi', 'FFA'), method='corr')\n",
@@ -2204,9 +2147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plot_model_comparison_trans(eval_result)"
@@ -2272,7 +2213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial4.ipynb
+++ b/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial4.ipynb
@@ -17,9 +17,7 @@
     "\n",
     "__Content reviewers:__ Samuele Bolotta, Yizhou Chen, RyeongKyung Yoon, Ruiyi Zhang, Lily Chamakura, Hlib Solodzhuk\n",
     "\n",
-    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk\n",
-    "\n",
-    "<br>\n",
+    "__Production editors:__ Konstantine Tsafatinos, Ella Batty, Spiros Chavlis, Samuele Bolotta, Hlib Solodzhuk, Patrick Mineault\n",
     "\n",
     "Acknowledgments: the tutorial outline was written by Heiko Schütt. The content was greatly improved by discussions with Heiko, Hlib, and Alish, and the insightful illustrations presented in the paper by Walther et al. (2016)\n"
    ]
@@ -50,17 +48,17 @@
     "\n",
     "By completing this tutorial, you will gain insights into:\n",
     "\n",
-    "1. Generating neural data with varied noise distributions. This section will guide you through the process of creating neural data, introducing variability in noise distributions. This step is crucial for understanding how different noise levels can affect data representation and subsequent analyses.\n",
+    "1. Generating neural data with varied noise distributions. This section will guide you through the process of creating neural data, introducing variability in noise distributions. This step will illustrate how different noise levels can affect data representation and subsequent analyses.\n",
     "\n",
-    "2. Understanding distance metrics - Euclidean and Mahalanobis. We will delve into two fundamental distance measures - Euclidean and Mahalanobis distances. Understanding these metrics is essential for analyzing the spatial relationships between data points in a representation space, with each metric offering unique insights based on the nature of the data.\n",
+    "2. Understanding distance metrics - Euclidean and Mahalanobis. Each metric offers unique insights into the geometry of the data.\n",
     "\n",
-    "3. Exploring the relationship between distance metrics and binary classification performance. This part of the tutorial emphasizes the significant relationship between distance measurements and the performance of binary classification tasks on a given pair of stimuli. Understanding this relationship is vital for developing more accurate and robust classification models.\n",
+    "3. Exploring the relationship between distance metrics and binary classification performance. This part of the tutorial emphasizes the relationship between distance measurements and the performance of binary classification tasks on a given pair of stimuli. Understanding this relationship will help us develop more accurate and robust classification models.\n",
     "\n",
-    "4. Addressing positively biased estimators through crossvalidation. We will explore the concept of positively biased estimators that arise when computing distances based on noisy pattern estimates. You will learn how crossvalidation techniques can be employed to correct this bias, ensuring a more accurate estimation of the underlying noise-free distance.\n",
+    "4. Addressing positively biased estimators through cross-validation. We will explore the concept of positively biased estimators that arise when computing distances based on noisy pattern estimates. You will learn how cross-validation techniques can be employed to correct this bias and obtain a more accurate estimate of the underlying noise-free distance.\n",
     "\n",
-    "5. Utilizing random projections to achieve unbiased distance estimates (Johnson–Lindenstrauss Lemma). This section introduces the Johnson–Lindenstrauss lemma, which suggests that random projections can be used to maintain the integrity of distance estimates in a lower-dimensional space. This concept is crucial for reducing dimensionality while preserving the relational structure of the data.\n",
+    "5. Using random projections to achieve unbiased distance estimates (Johnson–Lindenstrauss Lemma). This section introduces the Johnson–Lindenstrauss lemma, which suggests that random projections maintain the integrity of distance estimates in a lower-dimensional space. This concept is crucial for reducing dimensionality while preserving the relational structure of the data.\n",
     "\n",
-    "Throughout this tutorial, we will adhere to the notational conventions established by Walther et al. (2016) for all discussed distance measures. This consistency in notation will aid in understanding the mathematical formulations and their applications in representational similarity analysis and model comparison."
+    "Throughout this tutorial, we will adhere to the notational conventions established by [Walther et al. (2016)](https://pubmed.ncbi.nlm.nih.gov/26707889/) for all discussed distance measures. "
    ]
   },
   {
@@ -68,8 +66,7 @@
    "execution_count": null,
    "id": "b7cdfb17-5f87-4bcf-ac34-5248b9ef755e",
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -104,8 +101,7 @@
    "execution_count": null,
    "id": "dpa2AqZ0aALO",
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -119,8 +115,7 @@
    "execution_count": null,
    "id": "62ce1d24-edd9-487a-8f5d-4506c05a50a1",
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -132,7 +127,7 @@
     "import numpy as np\n",
     "import xarray as xr\n",
     "from scipy.stats import multivariate_normal\n",
-    "from sklearn.model_selection import LeaveOneOut\n",
+    "from sklearn.model_selection import StratifiedKFold\n",
     "from sklearn.discriminant_analysis import LinearDiscriminantAnalysis\n",
     "\n",
     "import rsatoolbox.data as rsd\n",
@@ -153,8 +148,7 @@
    "execution_count": null,
    "id": "90cf8ee2-9e0a-46c3-aca9-69974e66455f",
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -173,8 +167,7 @@
    "execution_count": null,
    "id": "127ad2ef-8b00-48c4-b8f2-1ecc7d58733d",
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -205,8 +198,8 @@
     "        X = xr.concat([i_stim_pattern, j_stim_pattern], dim=\"stim\")\n",
     "        y = X.stim.values\n",
     "\n",
-    "        loo = LeaveOneOut()\n",
-    "        for i, (train_index, test_index) in enumerate(loo.split(X)):\n",
+    "        cv = StratifiedKFold()\n",
+    "        for i, (train_index, test_index) in enumerate(cv.split(X, y)):\n",
     "            classifier.fit(X[train_index].values, y[train_index])\n",
     "            pred = classifier.predict(X[test_index])\n",
     "            acc.loc[i_stim_idx, j_stim_idx] += np.sum((pred==y[test_index]))\n",
@@ -401,8 +394,7 @@
    "execution_count": null,
    "id": "28b61a80-ceff-4af5-b122-d161b8ed8724",
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -589,7 +581,7 @@
     "execution": {}
    },
    "source": [
-    "<img src=\"https://github.com/neuromatch/NeuroAI_Course/blob/main/tutorials/ComparingArtificialAndBiologicalNetworks/static/response_matrix.png?raw=true\" width=600 />"
+    "<img src=\"https://github.com/neuromatch/NeuroAI_Course/blob/main/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/static/response_matrix.png?raw=true\" width=600 />"
    ]
   },
   {
@@ -599,19 +591,20 @@
     "execution": {}
    },
    "source": [
-    "&emsp;We will start by generating two neural datasets on a set of stimuli, represented as a stimulus-response matrix (stimuli x neurons). The first dataset will be low-dimensional, containing only two neurons, to help with illustration and visualization. The second dataset will be high-dimensional, containing 100 neurons. Each will have 10 stimuli. <br>\n",
-    "&emsp;The mean activity pattern of each stimulus (each row of the matrix) is generated by randomly sampling from a uniform distribution. To ensure that the differences between the mean activity of different stimuli are distinct for later illustration, we scale each activity pattern by a constant for the 100-neuron dataset. This is because the distances in a high-dimensional space tend to be similarly far apart. The implementations can be found above in the `generate_activity_patterns` function. <br>\n",
-    "&emsp;Then, we add two types of additive noise to the mean activity patterns. The first type of noise is independent and isotropic across neurons (**isotropic**) and stimuli (**homoscedastic**). The second type of noise is independent and isotropic across stimuli (**homoscedastic**) but correlated across neurons (**nonisotropic**). *Note that we are not focused on simulating biologically plausible activitity patterns*. The noise we add may lead to negative response values in the neural data.<br>\n",
-    "&emsp;We will provide various visualizations of the noise to help build intuitions. If you are curious about the implementations, please refer to the `get_isotropic_covariance` and `get_correlated_covariance` functions. "
+    "We will start by generating two neural datasets in response to a set of stimuli, represented as a stimulus-response matrix (stimuli x neurons). The first dataset will be low-dimensional, containing only two neurons, to help with illustration and visualization. The second dataset will be high-dimensional, containing 100 neurons. Each will have 10 stimuli. \n",
+    "\n",
+    "The mean activity pattern of each stimulus (each row of the matrix) is generated by randomly sampling from a uniform distribution. To ensure that the differences between the mean activity of different stimuli are distinct for later illustration, we scale each activity pattern by a constant for the 100-neuron dataset. This is because the distances in a high-dimensional space tend to be similarly far apart. The implementations can be found above in the `generate_activity_patterns` function. \n",
+    "\n",
+    "Then, we add two types of additive noise to the mean activity patterns. The first type of noise is independent and isotropic across neurons (**isotropic**) and stimuli (**homoscedastic**). The second type of noise is independent and isotropic across stimuli (**homoscedastic**) but correlated across neurons (**nonisotropic**). *Note that we are not focused on simulating biologically plausible activity patterns*. The noise we add may lead to negative response values in the neural data.\n",
+    "\n",
+    "We will provide various visualizations of the noise to help build intuitions. If you are curious about the implementations, please refer to the `get_isotropic_covariance` and `get_correlated_covariance` functions. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "f3299e47-ee31-4152-a59b-22ddd582fbf2",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "n_stimuli=10\n",
@@ -629,11 +622,14 @@
     "execution": {}
    },
    "source": [
-    "To simulate neuronal stochasticity, we introduce isotropic or correlated noise to the clean activity patterns and repeatedly obtain noisy neuronal response to the same stimulus (analogous to obtaining repeated measurements to the same stimulus for an experiment).\n",
+    "To simulate neuronal stochasticity, we introduce isotropic or correlated noise to the clean activity patterns and repeatedly obtain noisy neuronal responses to the same stimulus (analogous to obtaining repeated measurements to the same stimulus for an experiment).\n",
     "\n",
     "## Coding Exercise 1\n",
     "\n",
-    "How would you implement isotropic or correlated gaussian noise for two neurons? Create a covariance matrix for each type of noise."
+    "How would you implement isotropic or correlated Gaussian noise for two neurons? Create a covariance matrix for each type of noise:\n",
+    "\n",
+    "* For the isotropic Gaussian, let the variance of each neuron be 1.\n",
+    "* For the correlated Gaussian, let the variance of each neuron be 1 and the covariance be 0.6."
    ]
   },
   {
@@ -650,9 +646,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "69495198-8849-4357-b874-5a652aa0613d",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#################################################\n",
@@ -668,9 +662,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a06fd163-7975-47f7-ae5a-075ca750a2ea",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
@@ -686,7 +678,7 @@
     "execution": {}
    },
    "source": [
-    "We have implemented the covariance matrices for you. Run the following code block to generate noisy neural data for different correlation structures."
+    "We have implemented the covariance matrices for you. Run the following code block to generate 100 noisy neural responses to the 10 stimuli for different correlation structures."
    ]
   },
   {
@@ -694,8 +686,7 @@
    "execution_count": null,
    "id": "1fa28f6b-f47a-48e6-b029-7169d1325241",
    "metadata": {
-    "cellView": "form",
-    "execution": {}
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -732,9 +723,12 @@
     "execution": {}
    },
    "source": [
-    "Let's visualize the effect of the noise distribution on the distances between the stimuli using the two-neuron dataset. <br>\n",
-    "We can represent the noise distribution using a contour plot centered around the mean stimulus response. The contour plot represents a three-dimensional surface on a two-dimensional plane. In this case, the two dimensions represent the responses of the two neurons, and the contours indicate the probability density of the noise distribution. Darker colors indicate higher probability density. As we move further away from the mean response for a particular stimulus, the probability density decreases, meaning that the likelihood of observing a neural response at that point is lower. <br>\n",
-    "We have generated the clean activity patterns such that the Euclidean distances between stimulus pairs [$s_0$, $s_1$] and [$s_0$, $s_2$] is the same (see the arrows in the left panels). However, depending on the noise distribution, the discriminability of the stimulus pairs is different:\n",
+    "Let's visualize the effect of the noise distribution on the distances between the stimuli using the two-neuron dataset. \n",
+    "\n",
+    "We can represent the noise distribution using a contour plot centered around the mean stimulus response. The contour plot represents a three-dimensional surface on a two-dimensional plane. In this case, the two dimensions represent the responses of the two neurons, and the contours indicate the probability density of the noise distribution. Darker colors indicate higher probability density. As we move further away from the mean response for a particular stimulus, the probability density decreases, meaning that the likelihood of observing a neural response at that point is lower. \n",
+    "\n",
+    "We have generated the clean activity patterns such that the Euclidean distances between stimulus pairs [$s_0$, $s_1$] and [$s_0$, $s_2$] are the same (see the arrows in the left panels). However, depending on the noise distribution, the discriminability of the stimulus pairs is different:\n",
+    "\n",
     "- **Isotropic noise** (first row): the likelihood of observing the mean neural response of $s_1$ and $s_2$, given that the stimulus shown is $s_0$, is the same. The discriminability between a pair of stimuli is precisely defined by the Euclidean distance (Kriegeskorte & Diedrichsen, 2019).\n",
     "- **Correlated noise** (second row): even though the Euclidean distance between the two stimulus pairs is the same, the discriminability between $s_0$ and $s_1$ is lower than between $s_0$ and $s_2$. This is because the direction of the noise aligns with the signal direction for $s_0$ and $s_1$ (the line connecting their mean responses). As a result, the mean stimulus response of $s_1$ lies within the colored contours of stimulus $s_0$ (the probability density lies roughly between 0.06 and 0.08), while the mean stimulus response of $s_2$ lies outside the contours (which represent the regions where the probability density is close to 0). Namely, when the stimulus shown is $s_0$, the likelihood of observing a neural response that coincides with the mean response of $s_1$ is much higher than $s_2$. As we will see later, the discriminability depends on the Mahalanobis distance that takes into account the noise covariances between the neurons.\n"
    ]
@@ -743,12 +737,10 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1ee3ebd2-9600-40d6-8579-4f987672ca52",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "n_neurons=2\n",
+    "n_neurons = 2\n",
     "visualize_2d_noise(clean_dataset[n_neurons], isotropic_cov[n_neurons], correlated_cov[n_neurons], isotropic_noised_data[n_neurons], correlated_noised_data[n_neurons])"
    ]
   },
@@ -759,20 +751,23 @@
     "execution": {}
    },
    "source": [
-    "Let's visualize the covariance matrix for each type of noise distribution (row 1) and generate their corresponding samples (row 2) using the 100-neuron dataset. For isotropic noise, the covariance between different neurons is always 0, resulting in a diagonal covariance matrix. To create a correlated covariance matrix, we can use kernels like the Radial Basis Function (RBF) on the indices of the covariance matrix, defined as $\\Sigma_{i,j}=\\exp\\Big(-\\dfrac{||i-j||^2_2}{2l^2}\\Big)$, where $||i-j||_2$ represents the Euclidean distance between indices $i$ and $j$, and $l$ is a length scale parameter. Assuming that the matrix indices indicate the neurons' positions in the brain, the RBF would make neighboring neurons have larger covariances. In other words, we have generated a covariance matrix such that neighboring neurons tend to be correlated. To ensure that the correlated covariance matrix is well-conditioned and not singular, we added a small constant value to its diagonal entries. <br> Note: we intentionally set the noise magnitude to be large so that decoding the neural responses would not be perfect. This allows us to better illustrate the relationship between decoding accuracy and the distances between stimuli in Section 2.\n",
-    "\n"
+    "Let's create covariance matrices for the 100 neuron dataset. For isotropic noise, the covariance between different neurons remains 0, resulting in a diagonal covariance matrix. To create a correlated covariance matrix, we imagine that the neurons are spatially arranged in a line, and their correlation decays with distance:\n",
+    "\n",
+    "$$\\Sigma_{i,j}=\\exp\\Big(-\\dfrac{||i-j||^2_2}{2l^2}\\Big)$$\n",
+    "\n",
+    "Here $||i-j||_2$ represents the Euclidean distance between indices $i$ and $j$, and $l$ is a length scale parameter. Assuming that the matrix indices indicate the neurons' positions in the brain, neighboring neurons tend to be correlated. To ensure that the correlated covariance matrix is well-conditioned and not singular, we added a small constant value to its diagonal entries.\n",
+    "\n",
+    "Note: we intentionally set the noise magnitude to be large so that decoding the neural responses would not be perfect. This allows us to better illustrate the relationship between decoding accuracy and the distances between stimuli in Section 2.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "0a173d51-2cf9-4e40-8957-6d4cc8095c2c",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "n_neurons=100\n",
+    "n_neurons = 100\n",
     "visualize_100d_noise(isotropic_cov[n_neurons], correlated_cov[n_neurons])"
    ]
   },
@@ -794,11 +789,12 @@
     "execution": {}
    },
    "source": [
-    "As we alluded to earlier, for a pair of stimuli, there is a strong dependence between their distance and discriminability (defined by the performance of a binary classifier on the stimulus pair). Moreover, matching the type of distance computed (Euclidean vs. Mahalanobis) and the noise distribution (isotropic vs. correlated) is important. <br>\n",
-    "Let's briefly review how to compute the Euclidean and Mahalanobis distance. Let the activity patterns of stimuli $j$ and $k$ be $\\mathbf{b_j}$ and $\\mathbf{b_k}$ respectively.<br>\n",
+    "As we alluded to earlier, for a pair of stimuli, there is a strong dependence between their distance and discriminability (defined by the performance of a binary classifier on the stimulus pair). Moreover, matching the type of distance computed (Euclidean vs. Mahalanobis) and the noise distribution (isotropic vs. correlated) is important. <be>\n",
+    "\n",
+    "Let's briefly review how to compute the Euclidean and Mahalanobis distance. Let the activity patterns of stimuli $j$ and $k$ be $\\mathbf{b_j}$ and $\\mathbf{b_k}$ respectively.\n",
     "- The *squared* Euclidean distance is $$d^2_{\\text{Euclidean}}=||\\mathbf{b_i}-\\mathbf{b_j}||^2=(\\mathbf{b_i} - \\mathbf{b_j})(\\mathbf{b_i} - \\mathbf{b_j})^T$$\n",
-    "<br>\n",
-    "- The *squared* mahalanobis distance is $$d^2_{\\text{Mahalanobis}}=(\\mathbf{b_i} - \\mathbf{b_j})\\Sigma^{-1}(\\mathbf{b_i} - \\mathbf{b_j})^T$$ where $\\Sigma$ is the covariance matrix across the neurons. Taking the inverse of the covariance matrix makes the noise approximately independent and identically distributed. Intuitively, the noisier a neuron is, the more we down-weight its response.<br>\n",
+    "\n",
+    "- The *squared* mahalanobis distance is $$d^2_{\\text{Mahalanobis}}=(\\mathbf{b_i} - \\mathbf{b_j})\\Sigma^{-1}(\\mathbf{b_i} - \\mathbf{b_j})^T$$ where $\\Sigma$ is the covariance matrix across the neurons. Taking the inverse of the covariance matrix makes the noise approximately independent and identically distributed. Intuitively, the noisier a neuron is, the more we down-weight its response.\n",
     "Note: If we have repeated measurements for some stimulus $j$ ($\\mathbf{b_j^1}, \\mathbf{b_j^2}, ..., \\mathbf{b_j^n}$), we take the average and compute $\\mathbf{b_j}=\\dfrac{1}{n}\\sum_{i=1}^n \\mathbf{b_j^i}$"
    ]
   },
@@ -809,7 +805,8 @@
     "execution": {}
    },
    "source": [
-    "Let's first train a binary classifier for each pair of stimuli and calculate the decoding accuracy. We will use the **Fisher Linear Discriminant Analysis**. <br>\n",
+    "Let's first train a binary classifier for each pair of stimuli and calculate the decoding accuracy. We will use the **Fisher Linear Discriminant Analysis**. \n",
+    "\n",
     "To classify two stimuli $i$ and $j$, the Fisher discriminant decision criterion is a threshold on the dot product $\\mathbf{wb}^T > c$, where $\\mathbf{w}=(\\mathbf{b_i}-\\mathbf{b_j})_{\\text{train}}\\Sigma_{\\text{train}}^{-1}$ is the weight vector and $\\mathbf{b}$ is the stimulus pattern we want to classify.\n",
     "\n",
     "Execute this cell below to calculate the classifier performance on the noisy data (generated by adding either isotropic or correlated noise). **Notice that execution of this cell will take up to 3 minutes.**"
@@ -819,14 +816,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e8828f5b-d844-46c5-933d-488bcbd834e3",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "classifier=LinearDiscriminantAnalysis('svd')\n",
+    "classifier = LinearDiscriminantAnalysis()\n",
     "acc = {}\n",
     "for n_neurons in n_neurons_list:\n",
+    "    print(f\"Fitting for {n_neurons} neurons\")\n",
     "    acc[n_neurons]={}\n",
     "    acc[n_neurons]['isotropic'] = compute_classifier_acc(classifier, isotropic_noised_data[n_neurons], cov=isotropic_cov[n_neurons])\n",
     "    acc[n_neurons]['correlated'] = compute_classifier_acc(classifier, correlated_noised_data[n_neurons], cov=correlated_cov[n_neurons])"
@@ -842,7 +838,7 @@
     "Let's calculate the *squared* Euclidean and Mahalanobis distances between the **clean neural activity** patterns to study the relationship between these distances and classification accuracy.\n",
     "## Coding exercise 2\n",
     "\n",
-    "In this coding exercise, you only need to compute the *squared* Euclidean and mahalanobis distance for *one pair* of stimuli in the 2-neuron dataset.\n",
+    "In this coding exercise, you'll compute the *squared* Euclidean and Mahalanobis distance for *one pair* of stimuli in the 2-neuron dataset.\n",
     "\n",
     "You might be wondering why we are calculating the Mahalanobis distance for clean neural patterns, given that they are inherently noiseless. The reason is that our binary decoders are trained to classify noisy data. By computing the Mahalanobis distance between the clean neural activity patterns, we take the covariances into account, which allows us to better predict decoding accuracy (as you will see below). Consider the clean neural activity patterns as the mean neural response obtained from repeated measurements. If we collect many noisy measurements, our mean neural response will converge to the clean neural pattern."
    ]
@@ -856,7 +852,7 @@
    "source": [
     " The equations are provided again below:\n",
     "$$d^2_{\\text{Euclidean}}=||\\mathbf{b_j}-\\mathbf{b_k}||^2=(\\mathbf{b_i} - \\mathbf{b_j})(\\mathbf{b_i} - \\mathbf{b_j})^T$$\n",
-    "<br>\n",
+    "\n",
     "$$d^2_{\\text{Mahalanobis}}=(\\mathbf{b_i} - \\mathbf{b_j})\\Sigma^{-1}(\\mathbf{b_i} - \\mathbf{b_j})^T$$ where $\\Sigma$ is the covariance matrix across the neurons."
    ]
   },
@@ -864,9 +860,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1af582aa-d340-459f-8595-ce62f72fb3c4",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "n_neurons = 2\n",
@@ -885,9 +879,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3037225a-9294-47a2-835f-35d498a234e1",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#to_remove solution\n",
@@ -896,8 +888,8 @@
     "b_j = clean_dataset[n_neurons].loc[stimulus_idx[0]].values # select the stimulus response\n",
     "b_k = clean_dataset[n_neurons].loc[stimulus_idx[1]].values\n",
     "# compute the squared euclidean and mahalanobis distance, and then divide the distance by the number of neurons (2)\n",
-    "euclidean_dist = ((b_j-b_k) @ (b_j-b_k).T)/n_neurons\n",
-    "mahalanobis_dist = ((b_j-b_k) @ np.linalg.inv(correlated_cov[n_neurons]) @ (b_j-b_k).T)/n_neurons"
+    "euclidean_dist = ((b_j-b_k) @ (b_j-b_k).T) / n_neurons\n",
+    "mahalanobis_dist = ((b_j-b_k) @ np.linalg.inv(correlated_cov[n_neurons]) @ (b_j-b_k).T) / n_neurons"
    ]
   },
   {
@@ -917,7 +909,7 @@
     "execution": {}
    },
    "source": [
-    "1. For isotropic gaussian noise, what is the relationship between Euclidean and Mahalanobis distance?<br>\n",
+    "1. For isotropic gaussian noise, what is the relationship between Euclidean and Mahalanobis distance?\n",
     "**Hint**: Check the equations above. In the special case of an identity covariance matrix, i.e., $\\Sigma=I$, what is the inverse of $\\Sigma$?"
    ]
   },
@@ -925,15 +917,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9f65bc8b-0b5a-4902-9a01-33ea96dcbbe9",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#to_remove explanation\n",
     "\n",
     "\"\"\"\n",
-    "Discussion: For isotropic gaussian noise, what is the relationship between Euclidean and mahalanobis distance?\n",
+    "Discussion: For isotropic gaussian noise, what is the relationship between Euclidean and Mahalanobis distance?\n",
     "\n",
     "For isotropic Gaussian noise, the Euclidean distance and Mahalanobis distance are equivalent up to a constant factor. When the covariance matrix is an identity matrix, the Euclidean and Mahalanobis distances are exactly equal.\n",
     "\"\"\";"
@@ -946,16 +936,14 @@
     "execution": {}
    },
    "source": [
-    "The distances for all stimulus pairs in the 2-neuron and 100-neuron datasets are computed below. The <mark style=\"background-color: lightgray\">calc_rdm</mark> function is a wrapper around the <mark style=\"background-color: lightgray\">rsatoolbox.data.Dataset</mark> and <mark style=\"background-color: lightgray\">rsatoolbox.rdm.calc_rdm</mark> modules in [rsatoolbox](https://github.com/rsagroup/rsatoolbox) package. The rsatoolbox automatically computes distances for all possible pairs of stimuli. Namely, if our clean_dataset is an array of $k$ stimuli by $n$ neurons, then rsatoolbox.rdm.calc_rdm computes $k(k-1)/2$ distances."
+    "The distances for all stimulus pairs in the 2-neuron and 100-neuron datasets are computed below. The`calc_rdm` function is a wrapper around the `rsatoolbox.data.Dataset` and `rsatoolbox.rdm.calc_rdm` modules in the [rsatoolbox](https://github.com/rsagroup/rsatoolbox) package. The rsatoolbox automatically computes distances for all possible pairs of stimuli. Namely, if our `clean_dataset` is an array of $k$ stimuli by $n$ neurons, then `rsatoolbox.rdm.calc_rdm` computes $k(k-1)/2$ distances."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "5bc66507-3eff-4e28-9855-81ecdc5f7b26",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "rdm_euclidean, rdm_mahalanobis = {}, {}\n",
@@ -971,17 +959,16 @@
     "execution": {}
    },
    "source": [
-    "Check if the distances you just computed correspond to the ones calculated by rsatoolbox. Note that the calc_rdm function normalizes the distance by the number of channels (e.g. divides the distance by 2 for the 2-neuron dataset), so please divide your distance by the number of neurons (2) as well.<br>\n",
-    "You can obtain the distances by accessing the \"dissimilarities\" property in the namespace (rdm_euclidean[n_neurons].dissimilarities). The dissimilarites are ordered by the pattern_descriptors. If the pattern descriptor shows [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], then the $9(9-1)/2=45$ distances are ordered as $d_{0,1}$, $d_{0,2}$, $d_{0,3}$,..., $d_{i,i+1}$, $d_{i,i+2}$, ..., $d_{8,9}$."
+    "Verify that the distances you just computed correspond to the ones calculated by rsatoolbox. Note that the `calc_rdm` function normalizes the distance by the number of channels (e.g. divides the distance by 2 for the 2-neuron dataset), so please divide your distance by the number of neurons (2) as well.\n",
+    "\n",
+    "You can obtain the distances by accessing the `dissimilarities` property in the namespace (`rdm_euclidean[n_neurons].dissimilarities`). The `dissimilarities` are ordered by the `pattern_descriptors`. If the pattern descriptor shows [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], then the $9(9-1)/2=45$ distances are ordered as $d_{0,1}$, $d_{0,2}$, $d_{0,3}$,..., $d_{i,i+1}$, $d_{i,i+2}$, ..., $d_{8,9}$."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "878777ae-93f0-4667-afdc-ccf4aa15bd87",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "rdm_euclidean[2] # access dissimilarities by rdm_euclidean[2].dissimilarities"
@@ -1001,9 +988,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "865f440b-26f1-4edf-b981-2b6c17fdceb2",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "n_neurons = 2 # change to 100 to visualize the relationship between distance and decoding accuracy for the 100-neuron dataset\n",
@@ -1019,8 +1004,8 @@
    },
    "source": [
     "Notice that:\n",
-    "- For decoder trained to classify data with isotropic noise, the Euclidean distance predicts decoding accuracy better (higher correlation). The mahalanobis distance predicts worse because it uses the correlated covariance, which doesn't reflect the isotropic noise.\n",
-    "- For decoder trained to classify data with correlated noise, the mahalanobis distance that takes into account the correct noise covariance predicts decoding accuracy better."
+    "- For a decoder trained to classify data with isotropic noise, the Euclidean distance predicts decoding accuracy better (higher correlation). The Mahalanobis distance predictions are less accurate because it uses the correlated covariance, which doesn't reflect the isotropic noise.\n",
+    "- For a decoder trained to classify data with correlated noise, the Mahalanobis distance that takes into account the correct noise covariance predicts decoding accuracy better."
    ]
   },
   {
@@ -1031,7 +1016,7 @@
    },
    "source": [
     "---\n",
-    "# Section 3: Crossvalidated distances prevents the inflation of distance estimates by noise"
+    "# Section 3: Cross-validated distances prevent the inflation of distance estimates by noise"
    ]
   },
   {
@@ -1041,7 +1026,8 @@
     "execution": {}
    },
    "source": [
-    "If we calculate the Euclidean distance between the noisy activity patterns of each pair of stimuli and compare it with the ground truth Euclidean distance with no noise, we will observe that **the estimated Euclidean distance of noisy data generally yields higher values than expected**, particularly for the 100-neuron dataset. <br> \n",
+    "If we calculate the Euclidean distance between the **noisy** activity patterns of each pair of stimuli, we will observe that it's higher than in the no-noise condition. This is especially visible in the 100-neuron dataset. \n",
+    "\n",
     "To understand this positive bias of distances, imagine two activity patterns that are in truth identical. With the addition of the noise, the estimated distance between the noisy data will always be larger than 0. The noise makes the patterns dissimilar and inflates the distance (Walther et al. 2016). This effect is particularly pronounced in high-dimensional data."
    ]
   },
@@ -1059,12 +1045,10 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e311449f-719d-4dcb-863d-915b16d13443",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "noisy_rdm_euclidean={}\n",
+    "noisy_rdm_euclidean = {}\n",
     "for n_neurons in n_neurons_list:\n",
     "    noisy_rdm_euclidean[n_neurons] = {}\n",
     "    noisy_rdm_euclidean[n_neurons]['isotropic'] = calc_rdm(isotropic_noised_data[n_neurons], method='euclidean')\n",
@@ -1078,25 +1062,24 @@
     "execution": {}
    },
    "source": [
-    "To obtain unbiased estimate, we can split the data into independent sets and to cross-validate the difference between patterns across the two sets (Allefeld and Haynes, 2014; Nili et al. 2014).<br>\n",
-    "The cross-validated squared Euclidean (*crossclidean*) distance between two activity patterns $\\mathbf{b_i}$ and $\\mathbf{b_j}$ can be computed as: $$d^2_{\\text{Euclidean, crossvalidated}}=(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T$$\n",
-    "where we partition the repeated measurements of the activity patterns into a training and testing set before computing the differenc vectors independently.\n",
+    "To obtain an unbiased estimate, we can split the data into independent sets and cross-validate the difference between patterns across the two sets (Allefeld and Haynes, 2014; Nili et al. 2014).\n",
     "\n",
-    "rsatoolbox already implemented the crossvalidated distance. The general distance measure is called *crossnobis*, short for *cross-validated mahalanobis distance*. \n",
-    "$$d^2_{\\text{Mahalanobis, crossvalidated}}=(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}\\Sigma_{\\text{train}}^{-1}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T$$\n",
-    "If we assume the covariance noise structure is an identity matrix, then the crossnobis distance is equivalent to cross-validated euclidean distance."
+    "The cross-validated squared Euclidean distance–the so-called *crossclidian*–between two activity patterns $\\mathbf{b_i}$ and $\\mathbf{b_j}$ can be computed as: $$d^2_{\\text{Euclidean, cross-validated}}=(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T$$\n",
+    "where we partition the repeated measurements of the activity patterns into a training and testing set before computing the difference vectors independently.\n",
+    "\n",
+    "`rsatoolbox` has an implementation of the cross-validated distance. The general distance measure is called *crossnobis*, short for *cross-validated mahalanobis distance*. \n",
+    "$$d^2_{\\text{Mahalanobis, cross-validated}}=(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}\\Sigma_{\\text{train}}^{-1}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T$$\n",
+    "If we assume the covariance noise structure is an identity matrix, then the crossnobis distance is equivalent to the cross-validated Euclidean distance."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "9afb58f4-27f0-420d-b16d-28e6d11d4794",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "noisy_rdm_crossclidean={}\n",
+    "noisy_rdm_crossclidean = {}\n",
     "for n_neurons in n_neurons_list:\n",
     "    noisy_rdm_crossclidean[n_neurons] = {}\n",
     "    noisy_rdm_crossclidean[n_neurons]['isotropic'] = calc_rdm(isotropic_noised_data[n_neurons], method='crossnobis', noise=None)\n",
@@ -1110,16 +1093,14 @@
     "execution": {}
    },
    "source": [
-    "We can plot the (1) squared Euclidean distance and (2) cross-validated squared Euclidean distance against the true Euclidean distance for the 100-neuron dataset. Points falling on the diagonal line indicate an unbiased estimate of the distance; points above the diagonal line indicate an overestimation of the distance, and vice versa. <br>\n"
+    "Let's now plot the squared Euclidean distance and the cross-validated squared Euclidean distance against the true Euclidean distance for the 100-neuron dataset. Points falling on the diagonal line indicate an unbiased estimate of the distance; points above the diagonal line indicate an overestimation of the distance, and vice versa."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "f44f812e-849f-4278-b887-4045112ceff6",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plot_estimated_distance(rdm_euclidean, noisy_rdm_euclidean, noisy_rdm_crossclidean, n_neurons=100)"
@@ -1132,9 +1113,9 @@
     "execution": {}
    },
    "source": [
-    "In section 2, we used the Fisher Linear discriminant analysis (LDA) to decode stimulus pair and calculated decoding accuracy. The weight vector of the Fisher linear discriminant $\\mathbf{w}=(\\mathbf{b_i}-\\mathbf{b_j})_{\\text{train}}\\Sigma_{\\text{train}}^{-1}$. Do you notice any similarity with the cross-validated Mahalanobis distance $(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}\\Sigma_{\\text{train}}^{-1}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T$?<br><br>\n",
-    "In fact, if the test dataset only consists of one observation from each of the two classes ($\\mathbf{b_i^{\\textbf{test}}}$ and $\\mathbf{b_j}^{\\textbf{test}}$) and we subtract the mean pattern from both the training and the test dataset, then both observations in the test set will be correctly classified if $(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}\\Sigma_{\\text{train}}^{-1}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T>0$. <br><br>\n",
-    "The cross-validated Mahalanobis distance is closely related to the linear discrimiant (hence termed *linear discriminant contrast*, or *LDC*). In LDA, the discriminant makes binary classifications on each stimulus response and suffers from discretization and saturation of the classification accuracy. LDC, on the other hand, provides a continuous quantification of the discriminability between stimulus classes, avoiding the limitations of discretization and saturation (Walther et al. 2016)."
+    "In section 2, we used the Fisher Linear discriminant analysis (LDA) to decode stimuli and calculated decoding accuracy. The weight vector of the Fisher linear discriminant $\\mathbf{w}=(\\mathbf{b_i}-\\mathbf{b_j})_{\\text{train}}\\Sigma_{\\text{train}}^{-1}$. Do you notice any similarity with the cross-validated Mahalanobis distance $(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}\\Sigma_{\\text{train}}^{-1}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T$?\n",
+    "In fact, if the test dataset only consists of one observation from each of the two classes ($\\mathbf{b_i^{\\textbf{test}}}$ and $\\mathbf{b_j}^{\\textbf{test}}$) and we subtract the mean pattern from both the training and the test dataset, then both observations in the test set will be correctly classified if $(\\mathbf{b_i} - \\mathbf{b_j})_\\text{train}\\Sigma_{\\text{train}}^{-1}(\\mathbf{b_i} - \\mathbf{b_j})_\\text{test}^T>0$. \n",
+    "The cross-validated Mahalanobis distance is closely related to the linear discriminant (hence termed *linear discriminant contrast*, or *LDC*). In LDA, the discriminant makes binary classifications on each stimulus  and suffers from discretization and saturation of the classification accuracy. LDC, on the other hand, provides a continuous quantification of the discriminability between stimulus classes, avoiding the limitations of discretization and saturation (Walther et al. 2016)."
    ]
   },
   {
@@ -1146,8 +1127,10 @@
    "source": [
     "---\n",
     "# Section 4: The Johnson-Lindenstrauss Lemma\n",
-    "The Johnson-Lindenstrauss Lemma says that random projections approximately preserve euclidean distances with some distortion. The distortion $\\epsilon$ is bounded by the number of points in the original space, $N$, and the number of dimensions after the projection, $m$.\n",
-    "<br> We will see that we can embed points in a high-dimensional space into a reasonably low dimension."
+    "\n",
+    "The Johnson-Lindenstrauss Lemma says that random projections approximately preserve Euclidean distances with some distortion. The distortion $\\epsilon$ is bounded by the number of points in the original space, $N$, and the number of dimensions after the projection, $m$.\n",
+    "\n",
+    "We will see that we can embed points in a high-dimensional space into a reasonably low dimension."
    ]
   },
   {
@@ -1157,7 +1140,7 @@
     "execution": {}
    },
    "source": [
-    "We choose one pair of stimuli for illustration purpose. After we project the data into some dimension $m$ (where $m=2,4,8,...,512$), we can calculate the euclidean distance between the stimulus pair in the projected space and compare with the distance in the original space.<br>"
+    "We choose one pair of stimuli for illustration purposes. After we project the data onto a dimension $m$ (where $m=2, 4, 8,\\ldots, 512$), we calculate the Euclidean distance between the stimulus pair in the projected space and compare it with the distance in the original space."
    ]
   },
   {
@@ -1168,16 +1151,15 @@
    },
    "source": [
     "## Coding exercise 3\n",
-    "Complete the random projection matrix A from the original space to the $d$ dimensional space inside the for loop."
+    "\n",
+    "Generate a random projection matrix $A$ from the original space to the $d$ dimensional space inside the for loop. The entries of $A$ can be filled with random normal variables."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "11151d07-f096-40d2-8768-d85693fb23fc",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stim_idx = [0,1] # change stimulus index to visualize another pair of stimuli\n",
@@ -1208,9 +1190,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4eeb51b9-2bb6-4e3a-9169-bf3bd837cdd8",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# to_remove solution\n",
@@ -1255,26 +1235,26 @@
    "source": [
     "## Discussion\n",
     "\n",
-    "1. What is the distance between the two identical stimuli after random projection?"
+    "1. Does the amount of distortion after projection depend on the dimension $d$ of the original space? Observe the dimension $k$ that preserves Euclidean distance up to a small distortion for both the 2-neuron and 100-neuron datasets.\n",
+    "\n",
+    "2. What is the distance between two identical stimuli after random projection?"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "29ad7ab2-dd80-46df-b087-db086f5ca87e",
-   "metadata": {
-    "execution": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#to_remove explanation\n",
     "\n",
     "\"\"\"\n",
-    "Discussion: 1. Does the bound not depend on the dimension $d$ of the original space? Observe the dimension $k$ that preserves Euclidean distance up to a small distortion for both the 2-neuron and 100-neuron datasets.\n",
+    "Discussion: 1. Does the amount of distortion after projection depend on the dimension $d$ of the original space? Observe the dimension $k$ that preserves Euclidean distance up to a small distortion for both the 2-neuron and 100-neuron datasets.\n",
     "\n",
-    "2. What is the distance between the two identical stimuli after random projection?\n",
+    "2. What is the distance between two identical stimuli after random projection?\n",
     "\n",
-    "1. No. The dimension that preserves euclidean distance up to a small distortion for the 100-neuron dataset is not much larger than the one for the 2-neuron dataset.\n",
+    "1. No. Empirically, the dimension that preserves Euclidean distance up to a small distortion for the 100-neuron dataset is similar to the 2-neuron dataset. Theoretically, the distortion bound is independent of the original dimension (https://en.wikipedia.org/wiki/Johnson%E2%80%93Lindenstrauss_lemma).\n",
     "\n",
     "2. The distance is always 0.\n",
     "\"\"\";"
@@ -1300,11 +1280,11 @@
     "In this tutorial, we have learned:\n",
     "\n",
     "1. The differences between the (squared) Euclidean and Mahalanobis distance measures. The Mahalanobis distance takes into account the noise covariances between neurons, while the Euclidean distance assumes isotropic noise.\n",
-    "2. Representational distance reflects discriminability (decodability) between stimulus pair (Kriegeskorte & Diedrichsen, 2019).\n",
+    "2. Representational distance reflects discriminability (decodability) between stimulus pairs (Kriegeskorte & Diedrichsen, 2019).\n",
     "   - If we assume additive Gaussian noise that is independent and identically distributed across neurons (isotropic) and stimuli (homoscedastic), then the Euclidean distance in the multivariate response space precisely defines the discriminability of a pair of stimuli in the representation.\n",
     "   - If we assume that the noise is correlated across neurons (nonisotropic) and i.i.d across stimuli (homoscedastic), then the Mahalanobis distance defines the discriminability.\n",
     "3. Cross-validated distance estimators (cross-validated Euclidean or Mahalanobis distance) can remove the positive bias introduced by noise.\n",
-    "4. Johnson–Lindenstrauss Lemma shows that random projections preserves the Euclidean distance with some distortions. Crucially, the distortions does not depend on the dimensionality of the original space."
+    "4. The Johnson–Lindenstrauss Lemma shows that random projections preserve the Euclidean distance with some distortions. Crucially, the distortion does not depend on the dimensionality of the original space."
    ]
   }
  ],
@@ -1336,7 +1316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
T1:

* Clean up math, clean up text

T2:

* Clean up a lot of the text
* Moved from arccos of cos metric to straight cosine matrix (there was no explanation and it was confusing)
* Fixed MDS, it was being applied on a dissimilarity matrix, and so should have used `dissimilarity='precomputed'`

T3:

* Change one plot of voxel activity from image plot to line plot (the data was not arranged as an image, it was confusing)
* Clean up text

T4:

* Move from LOO validation to StratifiedKFold validation (much faster, still quite slow)
* Clean up text