### PR TITLE
Minor update re: np.arccos

### DIFF
--- a/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial2.ipynb
+++ b/tutorials/W1D3_ComparingArtificialAndBiologicalNetworks/W1D3_Tutorial2.ipynb
@@ -298,7 +298,7 @@
     "\n",
     "        rdms_comp = rsatoolbox.rdm.compare(rdms, rdms, method=rdm_comp_method)\n",
     "        if rdm_comp_method == 'cosine':\n",
-    "            rdms_comp = 1 - rdms_comp\n",
+    "            rdms_comp = np.arccos(rdms_comp)\n",
     "        rdms_comp = np.nan_to_num(rdms_comp, nan=0.0)\n",
     "\n",
     "        # Symmetrize\n",
@@ -1244,9 +1244,7 @@
     "\n",
     "$$\\hat M(\\text{layer i}, \\text{image j x image k})$$\n",
     "\n",
-    "We can then calculate the distances between the different rows of this new matrix. This new measure captures the distances between representational geometries of different layers. So we are now creating an RDM matrix of the RDM matrices!\n",
-    "\n",
-    "We compute the similarity between geometries using the cosine dissimilarity. The resulting matrix has the dimensions of `#layers` by `#layers`.\n",
+    "We can then calculate the cosine similarity between the different rows of this new matrix. By taking the arccos of this measure, we obtain a proper distance between representational geometries of different layers (Williams et al. 2021). So we are now creating an RDM matrix of the RDM matrices! The resulting matrix has the dimensions of `#layers` by `#layers`.\n",
     "\n",
     "The last step to visualize the path is to embed the distances between the geometries in a lower dimensional space. We use MDS to reduce the dimensions to 2 in order to show each computational step as a point in a 2D space."
    ]
@@ -1984,7 +1982,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.8.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Requested in an email from one of the content creators:

> I see you also logged another minor change to the code:

> Moved from arccos of cos metric to straight cosine matrix (there was no explanation and it was confusing)

> The change is from np.arccos(rdms_comp) to 1 - rdms_comp

> I discussed this with Niko (cc'd) today. Both of these are distance measures, but the difference is that arccos gives us an angle and makes the whole rdm comparison a metric. That's why we had it there. I think it would be good to go back to that.

> Niko and Heiko have a slide in their deck (see below) that explains what a metric is so we can actually add more explanation on that if you think that would help. 
