### PR TITLE
fixed a typo - Update W2D2_Tutorial3.ipynb

### DIFF
--- a/tutorials/W2D2_NeuroSymbolicMethods/W2D2_Tutorial3.ipynb
+++ b/tutorials/W2D2_NeuroSymbolicMethods/W2D2_Tutorial3.ipynb
@@ -1169,7 +1169,7 @@
     "execution": {}
    },
    "source": [
-    "As you can seem, the similarity is destroyed, which is what we should expect.\n",
+    "As you can see, the similarity is destroyed, which is what we should expect.\n",
     "\n",
     "Next, we are going to create a map out of our bound objects:\n",
     "\n",


### PR DESCRIPTION
## Solves #390 

In the section titled [Coding Exercise 3: Mixing Discrete Objects With Continuous Space](https://neuroai.neuromatch.io/tutorials/W2D2_NeuroSymbolicMethods/student/W2D2_Tutorial3.html#coding-exercise-3-mixing-discrete-objects-with-continuous-space), there is typo in the section. It says:

> As you can seem, the similarity is destroyed, which is what we should expect.

But it should be:

> As you can see, the similarity is destroyed, which is what we should expect.

**Seem** is changed to **see**.