### PR TITLE
Fix Exercise 2 code checker issue.

### DIFF
--- a/tutorials/W2D2_NeuroSymbolicMethods/W2D2_Tutorial2.ipynb
+++ b/tutorials/W2D2_NeuroSymbolicMethods/W2D2_Tutorial2.ipynb
@@ -626,7 +626,7 @@
     "        loss += log_loss(y_true, y_hat)\n",
     "\n",
     "        #update transform (T <- T - lr * (A* * (~rule)))\n",
-    "        transform -= (lr) * (... - (... * ~rule).v)\n",
+    "        transform -= (lr) * (... - (... * ...).v)\n",
     "        transform = transform / np.linalg.norm(transform)\n",
     "\n",
     "        #save predicted similarities if it is last iteration\n",


### PR DESCRIPTION
After confirming the code verification function, it's clear that ellipses can't be matched to corresponding solution code where the ellipsis is connected to another token and not separated by whitespace.

So you can't have this:

```
# Exercise
`transform -= (lr) * (transform - (a_true * ~...).v)`
# Solution
`transform -= (lr) * (transform - (a_true * ~rule).v)`
```

Instead it must be:

```
# Exercise
`transform -= (lr) * (transform - (a_true * ...).v)`
# Solution
`transform -= (lr) * (transform - (a_true * ~rule).v)`
```

Where the additional operator (`~`) has to be part of the solution and the ellipsis can't just match a variable name that is then being operated on. This example is the exact code fix that this PR corrects. 