### PR TITLE
Remove unnecessary graphical rendering deps in notebook-pr workflow

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: main
     paths: "**/*.ipynb"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -30,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Get commit message
         id: get-commit
@@ -43,7 +44,7 @@ jobs:
         env:
           COMMIT_MESSAGE: ${{ steps.get-commit.outputs.message }}
         run: |
-          if [[ "$COMMIT_MESSAGE" == *"skip ci"* ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" && "$COMMIT_MESSAGE" == *"skip ci"* ]]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -60,13 +61,13 @@ jobs:
           commit-message: ${{ steps.get-commit.outputs.message }}
 
       - name: Get changed files
-        if: steps.check-skip.outputs.skip != 'true'
+        if: steps.check-skip.outputs.skip != 'true' && github.event_name == 'pull_request'
         id: changed-files
         uses: tj-actions/changed-files@v35
 
       - name: Check if materials.yml changed
         id: materials-check
-        if: steps.check-skip.outputs.skip != 'true'
+        if: steps.check-skip.outputs.skip != 'true' && github.event_name == 'pull_request'
         run: |
           if [[ "${{ steps.changed-files.outputs.all_changed_files }}" =~ materials\.yml ]]; then
             echo "materials_changed=true" >> $GITHUB_OUTPUT
@@ -77,9 +78,17 @@ jobs:
       - name: Set notebook matrix
         id: set-matrix
         if: steps.check-skip.outputs.skip != 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            files=$(git ls-files '**/*.ipynb')
+          else
+            files="$CHANGED_FILES"
+          fi
+
           # Get filtered notebook list
-          nbs=$(nmaci select-notebooks ${{ steps.changed-files.outputs.all_changed_files }})
+          nbs=$(nmaci select-notebooks $files)
 
           if [ -z "$nbs" ]; then
             echo "No notebooks to process"
@@ -108,7 +117,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-env
@@ -120,6 +129,8 @@ jobs:
 
       - name: Setup rendering dependencies
         uses: ./.github/actions/setup-rendering-deps
+        with:
+          skip-backend: 'true'
 
       - name: Process notebook
         env:
@@ -174,7 +185,7 @@ jobs:
 
   finalize:
     needs: [setup, process]
-    if: always() && needs.setup.outputs.skip_ci != 'true' && needs.setup.outputs.has_notebooks == 'true'
+    if: always() && github.event_name == 'pull_request' && needs.setup.outputs.skip_ci != 'true' && needs.setup.outputs.has_notebooks == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -82,7 +82,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            files=$(git ls-files '**/*.ipynb')
+            files=$(git ls-files 'tutorials/*.ipynb' 'tutorials/**/*.ipynb')
           else
             files="$CHANGED_FILES"
           fi


### PR DESCRIPTION
We can't remove the whole `setup-rendering-deps` steps in `notebook-pr` because:
- many notebooks need the xkcd fonts
- W1D3 uses graphviz

However, `setup-rendering-deps` has a `skip-backend` option to skip some of the dependencies (e.g. ffmpeg).
I added that to `notebook-pr.yml` to make the installation faster and added a manual trigger that runs the workflow on all notebooks.
The manual workflow skips `finalize` so nothing gets committed.

I tested the new manual workflow here:https://github.com/OleBialas/NeuroAI_Course/actions/runs/25638754686
it surfaced a few errors, but none are related to the dependencies I removed